### PR TITLE
Infra Update: `spack.yaml` Simplification, new Projections

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -49,5 +49,5 @@ spack:
           - access-om3
           - access-om3-nuopc
         projections:
-          access-om3: '{name}/2024.09.0-{hash:7}'
+          access-om3: '{name}/2024.09.0'
           access-om3-nuopc: '{name}/0.3.1-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,25 +44,10 @@ spack:
     unify: true
   modules:
     default:
-      enable:
-        - tcl
-      roots:
-        tcl: $spack/../release/modules
-        lmod: $spack/../release/lmod
       tcl:
-        hash_length: 0
         include:
           - access-om3
           - access-om3-nuopc
-        exclude_implicits: true
-        all:
-          autoload: direct
-          conflict:
-            - '{name}'
-          environment:
-            set:
-              'SPACK_{name}_ROOT': '{prefix}'
         projections:
-          all: '{name}/{version}'
-          access-om3: '{name}/2024.09.0'
-          access-om3-nuopc: '{name}/0.3.1'
+          access-om3: '{name}/2024.09.0-{hash:7}'
+          access-om3-nuopc: '{name}/0.3.1-{hash:7}'


### PR DESCRIPTION
> [!NOTE]
> This is an infrastructure update, NOT a proper model update. No release will be created when merging this PR. 

In this PR:
* Simplify `spack.modules` section to not include parts already inherited from `spack-config`
* Update `spack.modules.default.tcl.projections` to have the `-{hash:7}` appended

Closes #17
