### PR TITLE
Pulling MOM6 upstream updates and applying patches

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.0.3.1'
+        - '@git.cbull/mom6_updates'
 
     # Other Dependencies
     esmf:


### PR DESCRIPTION
Preparing MOM6 updates to such we can update to the latest MOM-Ocean version and apply our patches. 

Will the '/' in the branch name work?