### PR TITLE
Upstream mom6 updates and applying patches

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
     access-om3-nuopc:
       require:
         - '@git.cbull_mom6_updates'
-
+ 
     # Other Dependencies
     esmf:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2024.09.0
+    - access-om3@git.2024.09.1
   packages:
     # Main Dependencies
     access-om3-nuopc:

--- a/spack.yaml
+++ b/spack.yaml
@@ -51,5 +51,5 @@ spack:
           - access-om3
           - access-om3-nuopc
         projections:
-          access-om3: '{name}/2024.09.0'
+          access-om3: '{name}/2024.09.1'
           access-om3-nuopc: '{name}/0.3.1-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -52,4 +52,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2024.09.1'
-          access-om3-nuopc: '{name}/0.3.1-{hash:7}'
+          access-om3-nuopc: '{name}/cbull_mom6_updates-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.cbull/mom6_updates'
+        - '@git.cbull_mom6_updates'
 
     # Other Dependencies
     esmf:

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.0.3.1'
+        - '@git.cbull/mom6_updates'
 
     # Other Dependencies
     esmf:


### PR DESCRIPTION
Preparing MOM6 updates to such we can update to the latest MOM-Ocean version and apply our patches.

---
:rocket: The latest prerelease `access-om3/pr23-3` is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/23#issuecomment-2530015780 :rocket:


