### PR TITLE
Pulling MOM6 upstream updates and applying patches

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.0.3.1'
+        - '@git.cbull_mom6_updates'
 
     # Other Dependencies
     esmf:

--- a/spack.yaml
+++ b/spack.yaml
@@ -52,4 +52,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2024.09.0'
-          access-om3-nuopc: '{name}/0.3.1-{hash:7}'
+          access-om3-nuopc: '{name}/cbull_mom6_updates-{hash:7}'


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-om3/pr32-7` at 7514acc46a34940ae7ba08f3c84181c377e171dc is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/32#issuecomment-2549896221 :rocket:


