### PR TITLE
Update spack.yaml to demonstrate new spack packages

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.07.08"
+    "spack-packages": "163-om3-components"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,11 +16,11 @@ spack:
     access3-exe:
       require:
         - '@git.2025.03.0'
-        - 'configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3'
+        - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
     access-cice:
       require:
         - '@git.2025.01.1'
-        - 'io_type=PIO'
+        - io_type=PIO
     access-mom6:
       require:
         - '@git.cmake_build'
@@ -55,7 +55,7 @@ spack:
         - '%gcc'
     all:
       require:
-        - %oneapi@2025.0.4
+        - '%oneapi@2025.0.4'
         - target=x86_64_v4
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
     access3-exe:
       require:
         - '@git.share_prototype'
-        - 'configurations=MOM6-CICE6-WW3'
+        - 'configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3'
     access-cice:
       require:
         - '@git.5-port_cmake_build'

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
     access3-exe:
       require:
         - '@git.share_prototype'
-        - 'configurations=CICE6'
+        - 'configurations=MOM6-CICE6'
     access-cice:
       require:
         - '@git.5-port_cmake_build'

--- a/spack.yaml
+++ b/spack.yaml
@@ -31,23 +31,23 @@ spack:
       - '@git.share_prototype'
     esmf:
       require:
-      - '@git.v8.7.0'
+        - '@git.v8.7.0'
     fms:
       require:
         - '@git.2024.03'
     parallelio:
       require:
-      - '@2.6.2'
+        - '@2.6.2'
     netcdf-c:
       require:
-      - '@4.9.2'
-      - build_system=cmake build_type=RelWithDebInfo
+        - '@4.9.2'
+        - build_system=cmake build_type=RelWithDebInfo
     netcdf-fortran:
       require:
-      - '@4.6.1'
+        - '@4.6.1'
     openmpi:
       require:
-      - '@4.1.7'
+        - '@4.1.7'
     all:
       require:
       - '%intel@2021.10.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -21,9 +21,11 @@ spack:
       require:
         - '@git.5-port_cmake_build'
         - 'io_type=PIO'
-    # access-mom6:
-    #   require:
-    #   - '@git.5-port_cmake_build io_type=PIO'
+    access-mom6:
+       require:
+       - '@git.cmake_build'
+    #access-generic-tracers:
+    #...
     # access-ww3:
     #   require:
     #   - '@git.5-port_cmake_build io_type=PIO'

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
     access3-exe:
       require:
         - '@git.share_prototype'
-        - 'configurations=MOM6-CICE6'
+        - 'configurations=MOM6-CICE6-WW3'
     access-cice:
       require:
         - '@git.5-port_cmake_build'
@@ -24,11 +24,9 @@ spack:
     access-mom6:
        require:
        - '@git.cmake_build'
-    #access-generic-tracers:
-    #...
-    # access-ww3:
-    #   require:
-    #   - '@git.5-port_cmake_build io_type=PIO'
+    access-ww3:
+      require:
+      - '@git.1-cmake_build'
     access3-share:
       require:
         - '@git.share_prototype'
@@ -51,10 +49,13 @@ spack:
     openmpi:
       require:
         - '@4.1.7'
+    gcc-runtime:
+      require:
+        - '%gcc'
     all:
       require:
-        - '%intel@2021.10.0'
-        - target=x86_64
+        - '%oneapi@2025.0.4'
+        - target=x86_64_v4
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - 'configurations=CICE6'
     access-cice:
       require:
-      - '@git.5-port_cmake_build io_type=PIO'
+        - '@git.5-port_cmake_build io_type=PIO'
     # access-mom6:
     #   require:
     #   - '@git.5-port_cmake_build io_type=PIO'
@@ -28,7 +28,7 @@ spack:
     #   - '@git.5-port_cmake_build io_type=PIO'
     access3-share:
       require:
-      - '@git.share_prototype'
+        - '@git.share_prototype'
     esmf:
       require:
         - '@git.v8.7.0'
@@ -50,8 +50,8 @@ spack:
         - '@4.1.7'
     all:
       require:
-      - '%intel@2021.10.0'
-      - target=x86_64
+        - '%intel@2021.10.0'
+        - target=x86_64
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,7 @@ spack:
   specs:
   - access-om3@git.2025.x.0
   packages:
-    access3-exe:
+    access3:
       require:
         - '@git.2025.03.0'
         - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
@@ -68,4 +68,4 @@ spack:
           - access3-exe
         projections:
           access-om3: '{name}/2025.x.0'
-          access3-exe: '{name}/share_prototype-{hash:7}'
+          access3: '{name}/share_prototype-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -64,4 +64,4 @@ spack:
           - access3-exe
         projections:
           access-om3: '{name}/2025.x.0'
-          access3-exe: '{name}/git.share_prototype-{hash:7}'
+          access3-exe: '{name}/share_prototype-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,7 +23,7 @@ spack:
         - 'io_type=PIO'
     access-mom6:
        require:
-       - '@git.ddd3902d851ccb50fc3e62f27398b48b5294085d'
+       - '@git.cmake_build'
        - '+asymmetric_mem'
     access-ww3:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,8 @@ spack:
         - 'configurations=CICE6'
     access-cice:
       require:
-        - '@git.5-port_cmake_build io_type=PIO'
+        - '@git.5-port_cmake_build'
+        - 'io_type=PIO'
     # access-mom6:
     #   require:
     #   - '@git.5-port_cmake_build io_type=PIO'

--- a/spack.yaml
+++ b/spack.yaml
@@ -24,6 +24,7 @@ spack:
     access-mom6:
        require:
        - '@git.cmake_build'
+       - '+asymmetric_mem'
     access-ww3:
       require:
       - '@git.1-cmake_build'

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,43 +4,54 @@
 # configuration settings.
 # Instructions for editing this file are found in 
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
 spack:
+  # add package specs to the `specs` list
   specs:
-    - access-om3@git.2024.09.0
+  - access-om3@git.2025.x.0
   packages:
-    # Main Dependencies
-    access-om3-nuopc:
+    access3-exe:
       require:
-        - '@git.0.3.1'
-
-    # Other Dependencies
+        - '@git.share_prototype'
+        - 'configurations=CICE6'
+    access-cice:
+      require:
+      - '@git.5-port_cmake_build io_type=PIO'
+    # access-mom6:
+    #   require:
+    #   - '@git.5-port_cmake_build io_type=PIO'
+    # access-ww3:
+    #   require:
+    #   - '@git.5-port_cmake_build io_type=PIO'
+    access3-share:
+      require:
+      - '@git.share_prototype'
     esmf:
       require:
-        - '@8.5.0'
-    parallelio:
-      require:
-        - '@2.6.2'
-    netcdf-c:
-      require:
-        - '@4.9.2'
-        - build_system=cmake build_type=RelWithDebInfo
-    netcdf-fortran:
-      require:
-        - '@4.6.1'
+      - '@git.v8.7.0'
     fms:
       require:
-        - '@2023.02'
+        - '@git.2024.03'
+    parallelio:
+      require:
+      - '@2.6.2'
+    netcdf-c:
+      require:
+      - '@4.9.2'
+      - build_system=cmake build_type=RelWithDebInfo
+    netcdf-fortran:
+      require:
+      - '@4.6.1'
     openmpi:
       require:
-        - '@4.1.5'
-    fortranxml:
-      require:
-        - '@4.1.2'
-
+      - '@4.1.7'
     all:
       require:
-        - '%intel@2021.10.0'
-        - 'target=x86_64'
+      - '%intel@2021.10.0'
+      - target=x86_64
   view: true
   concretizer:
     unify: true
@@ -49,7 +60,7 @@ spack:
       tcl:
         include:
           - access-om3
-          - access-om3-nuopc
+          - access3-exe
         projections:
-          access-om3: '{name}/2024.09.0'
-          access-om3-nuopc: '{name}/0.3.1-{hash:7}'
+          access-om3: '{name}/2025.x.0'
+          access3-exe: '{name}/git.share_prototype-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - 'configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3'
     access-cice:
       require:
-        - '@git.5-port_cmake_build'
+        - '@git.421a90ccc47b7861afa48f5384f642715c5560e1'
         - 'io_type=PIO'
     access-mom6:
        require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,7 +29,7 @@ spack:
       - '@git.1-cmake_build'
     access3-share:
       require:
-        - '@git.share_prototype'
+        - '@git.db7726a75de14a02acb3ee09efe6b3adf8db5c5e'
     esmf:
       require:
         - '@git.v8.7.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,22 +15,22 @@ spack:
   packages:
     access3-exe:
       require:
-        - '@git.share_prototype'
+        - '@git.2025.03.0'
         - 'configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3'
     access-cice:
       require:
-        - '@git.421a90ccc47b7861afa48f5384f642715c5560e1'
+        - '@git.2025.01.1'
         - 'io_type=PIO'
     access-mom6:
-       require:
-       - '@git.cmake_build'
-       - '+asymmetric_mem'
+      require:
+        - '@git.cmake_build'
+        - '+asymmetric_mem'
     access-ww3:
       require:
-      - '@git.97655811bb003567c0f87b8aecb0489e85a5d446'
+        - '@git.2025.03.0'
     access3-share:
       require:
-        - '@git.db7726a75de14a02acb3ee09efe6b3adf8db5c5e'
+        - '@git.2025.03.0'
     esmf:
       require:
         - '@git.v8.7.0'
@@ -55,7 +55,7 @@ spack:
         - '%gcc'
     all:
       require:
-        - '%oneapi@2025.0.4'
+        - %oneapi@2025.0.4
         - target=x86_64_v4
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,11 +23,11 @@ spack:
         - 'io_type=PIO'
     access-mom6:
        require:
-       - '@git.cmake_build'
+       - '@git.ddd3902d851ccb50fc3e62f27398b48b5294085d'
        - '+asymmetric_mem'
     access-ww3:
       require:
-      - '@git.1-cmake_build'
+      - '@git.97655811bb003567c0f87b8aecb0489e85a5d446'
     access3-share:
       require:
         - '@git.db7726a75de14a02acb3ee09efe6b3adf8db5c5e'


### PR DESCRIPTION
Demo with CICE6 as only model component

Spack-packages PR: 

https://github.com/ACCESS-NRI/spack-packages/pull/171

Component versions:

- [ ] https://github.com/ACCESS-NRI/CICE/compare/main...ACCESS-NRI:CICE:5-port_cmake_build
- [ ] https://github.com/ACCESS-NRI/access3-share/compare/main...share_prototype
- [ ] https://github.com/ACCESS-NRI/MOM6/tree/cmake_build
- [ ] https://github.com/ACCESS-NRI/WW3/tree/1-cmake_build
---
:rocket: The latest prerelease `access-om3/pr35-10` at 5e067396cb284ee451fd355364a22f12df554e6d is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/35#issuecomment-2603625977 :rocket:











---
:rocket: The latest prerelease `access-om3/pr35-25` at 5e067396cb284ee451fd355364a22f12df554e6d is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/35#issuecomment-2696293797 :rocket:
















---
:rocket: The latest prerelease `access-om3/pr35-51` at 5d3d92c7ee204d270f44ab471d838cd60617fc39 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/35#issuecomment-2777445857 :rocket:

























