### PR TITLE
Deploy new ACCESS-OM3 0.4.0 using COSIMA build system

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -13,6 +13,7 @@ spack:
       require:
         - '@git.0.4.0'
         - +mom_symmetric
+        - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
 
     # Other Dependencies
     esmf:

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,6 +12,7 @@ spack:
     access-om3-nuopc:
       require:
         - '@git.0.3.1'
+        - +mom_symmetric
 
     # Other Dependencies
     esmf:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,18 +6,18 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2024.09.0
+    - access-om3@git.2025.01.0
   packages:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.0.3.1'
+        - '@git.0.4.0'
         - +mom_symmetric
 
     # Other Dependencies
     esmf:
       require:
-        - '@8.5.0'
+        - '@git.v8.7.0'
     parallelio:
       require:
         - '@2.6.2'
@@ -30,10 +30,10 @@ spack:
         - '@4.6.1'
     fms:
       require:
-        - '@2023.02'
+        - '@git.2024.03'
     openmpi:
       require:
-        - '@4.1.5'
+        - '@4.1.7'
     fortranxml:
       require:
         - '@4.1.2'
@@ -52,5 +52,5 @@ spack:
           - access-om3
           - access-om3-nuopc
         projections:
-          access-om3: '{name}/2024.09.0'
-          access-om3-nuopc: '{name}/0.3.1-{hash:7}'
+          access-om3: '{name}/2025.01.0'
+          access-om3-nuopc: '{name}/0.4.0-{hash:7}'


### PR DESCRIPTION
Deploy

https://github.com/COSIMA/access-om3/releases/tag/0.4.0

with new update components per https://github.com/COSIMA/access-om3/issues/209

---
:rocket: The latest prerelease `access-om3/pr39-2` at 6ef4337a09a2002c94e0b4afadfb391523e3280b is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/39#issuecomment-2620184677 :rocket:

