### PR TITLE
Deploy FRE-NCtools prerelease

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.07.08"
+    "spack-packages": "2025.02.1"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - fre-nctools@2024.03 %intel@2021.2.0 target=x86_64
+    - fre-nctools@git.2024.03 %intel@2021.2.0 target=x86_64
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,48 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.01.0
-  packages:
-    # Main Dependencies
-    access-om3-nuopc:
-      require:
-        - '@git.0.4.0'
-        - +mom_symmetric
-        - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-
-    # Other Dependencies
-    esmf:
-      require:
-        - '@git.v8.7.0'
-    parallelio:
-      require:
-        - '@2.6.2'
-    netcdf-c:
-      require:
-        - '@4.9.2'
-        - build_system=cmake build_type=RelWithDebInfo
-    netcdf-fortran:
-      require:
-        - '@4.6.1'
-    fms:
-      require:
-        - '@git.2024.03'
-    openmpi:
-      require:
-        - '@4.1.7'
-    fortranxml:
-      require:
-        - '@4.1.2'
-
-    # Tools
-    fre-nctools:
-      require:
-        - '@2024.05'
-
-    all:
-      require:
-        - '%intel@2021.10.0'
-        - 'target=x86_64'
+    - fre-nctools@2024.03 %intel@2021.2.0 target=x86_64
   view: true
   concretizer:
     unify: true
@@ -55,10 +14,6 @@ spack:
     default:
       tcl:
         include:
-          - access-om3
-          - access-om3-nuopc
           - fre-nctools
         projections:
-          access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/0.4.0-{hash:7}'
           fre-nctools: '{name}/2024.05'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - fre-nctools@git.2024.03 %intel@2021.2.0 target=x86_64
+    - fre-nctools@git.2024.05 %intel@2021.2.0 target=x86_64
   view: true
   concretizer:
     unify: true
@@ -16,4 +16,4 @@ spack:
         include:
           - fre-nctools
         projections:
-          fre-nctools: '{name}/2024.05'
+          fre-nctools: '{name}/git.2024.05'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,12 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - fre-nctools@git.2024.05 %intel@2021.2.0 target=x86_64
+    - fre-nctools@git.2024.05
+  packages:
+    all:
+      require:
+        - '%intel@2021.10.0'
+        - 'target=x86_64'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,4 +16,4 @@ spack:
         include:
           - fre-nctools
         projections:
-          fre-nctools: '{name}/git.2024.05'
+          fre-nctools: '{name}/2024.05'

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,6 +8,9 @@ spack:
   specs:
     - fre-nctools@git.2024.05
   packages:
+    fre-nctools:
+      require:
+        - '@2024.05'
     all:
       require:
         - '%intel@2021.10.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,7 +7,6 @@
 spack:
   specs:
     - access-om3@git.2025.01.0
-    - fre-nctools@2024.05
   packages:
     # Main Dependencies
     access-om3-nuopc:
@@ -39,6 +38,11 @@ spack:
     fortranxml:
       require:
         - '@4.1.2'
+
+    # Tools
+    fre-nctools:
+      require:
+        - '@2024.05'
 
     all:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,7 @@
 spack:
   specs:
     - access-om3@git.2025.01.0
+    - fre-nctools@2024.05
   packages:
     # Main Dependencies
     access-om3-nuopc:
@@ -52,6 +53,8 @@ spack:
         include:
           - access-om3
           - access-om3-nuopc
+          - fre-nctools
         projections:
           access-om3: '{name}/2025.01.0'
           access-om3-nuopc: '{name}/0.4.0-{hash:7}'
+          fre-nctools: '{name}/2024.05'


### PR DESCRIPTION
**DO NOT MERGE**

This is a PR to create a prerelease of FRE-NCtools. This is very much a stop-gap to provide a deployment of FRE-NCtools while we work out the best way to release these sorts of tools.

To get around the CI checks, this PR _replaces_ the `access-om3` spec in the environment with `fre-nctools`.

See #44 

---
:rocket: The latest prerelease `access-om3/pr45-3` at bad5555cae69c4fd3a1e7dba3dfc3a8787d4db46 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/45#issuecomment-2639605295 :rocket:








