### PR TITLE
Debugging non-reproducibility of ACCESS-NRI 0.3.1 -> 0.4.0

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.96f91599f746b4866bbd3f05ee6eb192ba70d391'
+        - '@git.31eefa9a40f7fd9fd5fd030cbdf009d4eb66a5e9'
 
     # Other Dependencies
     esmf:
@@ -52,4 +52,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/96f91599f746b4866bbd3f05ee6eb192ba70d391-{hash:7}'
+          access-om3-nuopc: '{name}/31eefa9a40f7fd9fd5fd030cbdf009d4eb66a5e9-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,12 +11,12 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.0573ee6b5e5fed7e88fe366d30923ba79934ffb4'
+        - '@git.00e8d3486d62e0065ba46d8627ef15020f36f737'
 
     # Other Dependencies
     esmf:
       require:
-        - '@8.5.0'
+        - '@git.v8.7.0'
     parallelio:
       require:
         - '@2.6.2'
@@ -52,4 +52,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/0573ee6b5e5fed7e88fe366d30923ba79934ffb4-{hash:7}'
+          access-om3-nuopc: '{name}/00e8d3486d62e0065ba46d8627ef15020f36f737-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,11 +12,12 @@ spack:
     access-om3-nuopc:
       require:
         - '@git.96f91599f746b4866bbd3f05ee6eb192ba70d391'
+        - +mom_symmetric
 
     # Other Dependencies
     esmf:
       require:
-        - '@8.6.0'
+        - '@8.5.0'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,12 +11,12 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.00e8d3486d62e0065ba46d8627ef15020f36f737'
+        - '@git.96f91599f746b4866bbd3f05ee6eb192ba70d391'
 
     # Other Dependencies
     esmf:
       require:
-        - '@git.v8.7.0'
+        - '@8.6.0'
     parallelio:
       require:
         - '@2.6.2'
@@ -52,4 +52,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/00e8d3486d62e0065ba46d8627ef15020f36f737-{hash:7}'
+          access-om3-nuopc: '{name}/96f91599f746b4866bbd3f05ee6eb192ba70d391-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.af996ad20fb123817fc56cda7b4c60c7ff626803'
+        - '@git.0573ee6b5e5fed7e88fe366d30923ba79934ffb4'
 
     # Other Dependencies
     esmf:
@@ -52,4 +52,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/af996ad20fb123817fc56cda7b4c60c7ff626803-{hash:7}'
+          access-om3-nuopc: '{name}/0573ee6b5e5fed7e88fe366d30923ba79934ffb4-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.31eefa9a40f7fd9fd5fd030cbdf009d4eb66a5e9'
+        - '@git.af996ad20fb123817fc56cda7b4c60c7ff626803'
 
     # Other Dependencies
     esmf:
@@ -52,4 +52,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/31eefa9a40f7fd9fd5fd030cbdf009d4eb66a5e9-{hash:7}'
+          access-om3-nuopc: '{name}/af996ad20fb123817fc56cda7b4c60c7ff626803-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,14 +11,12 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.0.4.0'
-        - +mom_symmetric
-        - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
+        - '@git.96f91599f746b4866bbd3f05ee6eb192ba70d391'
 
     # Other Dependencies
     esmf:
       require:
-        - '@git.v8.7.0'
+        - '@8.5.0'
     parallelio:
       require:
         - '@2.6.2'
@@ -31,10 +29,10 @@ spack:
         - '@4.6.1'
     fms:
       require:
-        - '@git.2024.03'
+        - '@2023.02'
     openmpi:
       require:
-        - '@4.1.7'
+        - '@4.1.5'
     fortranxml:
       require:
         - '@4.1.2'
@@ -54,4 +52,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/0.4.0-{hash:7}'
+          access-om3-nuopc: '{name}/96f91599f746b4866bbd3f05ee6eb192ba70d391-{hash:7}'


### PR DESCRIPTION
This is a PR to debug and document where we lost reproducibility when we updated from 0.3.1 to 0.4.0. The context is that our repro tests [had a bug](https://github.com/ACCESS-NRI/model-config-tests/issues/100) and was effectively always reporting reproducible runs. We thus updated components from 0.3.1 to 0.4.0 under the impression that the updates were not answer-changing when in fact they are.

Companion PR to https://github.com/ACCESS-NRI/access-om3-configs/pull/173. See also https://github.com/COSIMA/access-om3/issues/266

---
:rocket: The latest prerelease `access-om3/pr47-11` at 93820091449bd4380c6f6d4d37c09e077845fc57 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/47#issuecomment-2677164164 :rocket:







