### PR TITLE
Update MOM to 0.4.0 with vertex bug fix (tmp build – do not merge)

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,10 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.0.4.0'
-        - +mom_symmetric
-        - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-
+        - '@git.65a04e8033c23c347e96630e5af21d38b4730d84'
     # Other Dependencies
     esmf:
       require:
@@ -54,4 +51,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/0.4.0-{hash:7}'
+          access-om3-nuopc: '{name}/65a04e8033c23c347e96630e5af21d38b4730d84-{hash:7}'


### PR DESCRIPTION
This PR updates MOM to the latest version in 0.4.0 and includes a vertex bug fix from https://github.com/noaA-GFDL/mom6/pull/824. The remaining components continue to use versions from 0.3.0.

This is only a tmp build and should not be merged. 



---
:rocket: The latest prerelease `access-om3/pr48-3` at 3648489ba05cec0704743701a5c2720a9b8f425a is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/48#issuecomment-2670523803 :rocket:


