### PR TITLE
Update MOM latest version in 0.4.0 and a vertex bug fix with rest comps in 0.3.1

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.02e6d0d293faa5c707b5489aa93cf8aafe701c2a'
+        - '@git.8d2124a9a2e6ce305cdb820c197cc26b86321c0a'
     # Other Dependencies
     esmf:
       require:
@@ -51,4 +51,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/02e6d0d293faa5c707b5489aa93cf8aafe701c2a-{hash:7}'
+          access-om3-nuopc: '{name}/8d2124a9a2e6ce305cdb820c197cc26b86321c0a-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.3c0a6eb02db871244c3e1557dd7ea1a1d4f44fbc'
+        - '@git.c8d0cf4c700cc92662ce77fbf3d310c4662cb39f'
     # Other Dependencies
     esmf:
       require:
@@ -51,4 +51,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/3c0a6eb02db871244c3e1557dd7ea1a1d4f44fbc-{hash:7}'
+          access-om3-nuopc: '{name}/c8d0cf4c700cc92662ce77fbf3d310c4662cb39f-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,14 +11,11 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.0.4.0'
-        - +mom_symmetric
-        - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-
+        - '@git.d7bea3f087586de06bf9a4fd03f76707eec77fff'
     # Other Dependencies
     esmf:
       require:
-        - '@git.v8.7.0'
+        - '@8.5.0'
     parallelio:
       require:
         - '@2.6.2'
@@ -31,10 +28,10 @@ spack:
         - '@4.6.1'
     fms:
       require:
-        - '@git.2024.03'
+        - '@git.2023.02'
     openmpi:
       require:
-        - '@4.1.7'
+        - '@4.1.5'
     fortranxml:
       require:
         - '@4.1.2'
@@ -54,4 +51,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/0.4.0-{hash:7}'
+          access-om3-nuopc: '{name}/d7bea3f087586de06bf9a4fd03f76707eec77fff-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,15 +7,16 @@
 spack:
   specs:
     - access-om3@git.2025.01.0
+    - 'esmf@git.v8.7.0 /nuesvebcvtdv7pntu2oomfmwtnmbbllt' 
   packages:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.c8d0cf4c700cc92662ce77fbf3d310c4662cb39f'
+        - '@git.df0cb99af80c59158da4acb9b624a37ec9261912'
     # Other Dependencies
-    esmf:
-      require:
-        - '@git.v8.7.0'
+    #esmf:
+    #  require:
+    #    - '@git.v8.7.0'
     parallelio:
       require:
         - '@2.6.2'
@@ -51,4 +52,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/c8d0cf4c700cc92662ce77fbf3d310c4662cb39f-{hash:7}'
+          access-om3-nuopc: '{name}/df0cb99af80c59158da4acb9b624a37ec9261912-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.108442bc0cbfcbfa780e7eeccb6f59b122a9601b'
+        - '@git.3c0a6eb02db871244c3e1557dd7ea1a1d4f44fbc'
     # Other Dependencies
     esmf:
       require:
@@ -51,4 +51,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/108442bc0cbfcbfa780e7eeccb6f59b122a9601b-{hash:7}'
+          access-om3-nuopc: '{name}/3c0a6eb02db871244c3e1557dd7ea1a1d4f44fbc-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - '@8.5.0'
+        - '@git.v8.7.0'
     parallelio:
       require:
         - '@2.6.2'
@@ -31,7 +31,7 @@ spack:
         - '@git.2023.02'
     openmpi:
       require:
-        - '@4.1.5'
+        - '@4.1.7'
     fortranxml:
       require:
         - '@4.1.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,7 +29,7 @@ spack:
         - '@4.6.1'
     fms:
       require:
-        - '@git.2023.02'
+        - '@git.2024.03'
     openmpi:
       require:
         - '@4.1.7'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.d7bea3f087586de06bf9a4fd03f76707eec77fff'
+        - '@git.02e6d0d293faa5c707b5489aa93cf8aafe701c2a'
     # Other Dependencies
     esmf:
       require:
@@ -51,4 +51,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/d7bea3f087586de06bf9a4fd03f76707eec77fff-{hash:7}'
+          access-om3-nuopc: '{name}/02e6d0d293faa5c707b5489aa93cf8aafe701c2a-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.8d2124a9a2e6ce305cdb820c197cc26b86321c0a'
+        - '@git.108442bc0cbfcbfa780e7eeccb6f59b122a9601b'
     # Other Dependencies
     esmf:
       require:
@@ -51,4 +51,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/8d2124a9a2e6ce305cdb820c197cc26b86321c0a-{hash:7}'
+          access-om3-nuopc: '{name}/108442bc0cbfcbfa780e7eeccb6f59b122a9601b-{hash:7}'


### PR DESCRIPTION
This PR updates MOM to the latest version in 0.4.0 and includes a vertex bug fix from https://github.com/NOAA-GFDL/MOM6/pull/824. ~The remaining components continue to use versions from 0.3.1.~ 


It also updates CMEPS, CDEPS, and share to their latest versions.

 - MOM6 without symmetric variant in 0.4.0 build
 - CICE in 0.4.0 build
 - CMEPS: 1.0.39
 - CDEPS: 1.0.64
 - share: 1.1.9
 - FMS 2024.03

This is only a tmp build and should not be merged.

---
:rocket: The latest prerelease `access-om3/pr49-10` at ca2cda1ec9bcf25e03a89263d74ec4e886bb766e is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/49#issuecomment-2704974818 :rocket:









