### PR TITLE
Test building libraries for updated CM3

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,9 +11,10 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.0.4.0'
+        - '@git.f4784136f017d4d51915439666420dd61ff04854'
         - +mom_symmetric
-        - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
+        - configurations=MOM6-CICE6
+        - +install_libraries
 
     # Other Dependencies
     esmf:
@@ -54,4 +55,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.0'
-          access-om3-nuopc: '{name}/0.4.0-{hash:7}'
+          access-om3-nuopc: '{name}/f4784136f017d4d51915439666420dd61ff04854-{hash:7}'


### PR DESCRIPTION
A small test of building OM3 libraries for CM3 with updated MOM and CMEPs

---
:rocket: The latest prerelease `access-om3/pr53-1` at 28929971e499085d40a2f3d25153ce50cc77dd76 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/53#issuecomment-2683726788 :rocket:
