### PR TITLE
Update spack-packages

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.07.08"
+    "spack-packages": "2025.03.001"
 }


### PR DESCRIPTION
Draft PR to create a prerelease using latest tag of `spack-packages`

---
:rocket: The latest prerelease `access-om3/pr59-1` at b6666103304a4ead0eb46e2e180afb0e5732c204 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/59#issuecomment-2702724154 :rocket:
