### PR TITLE
Next release: 2025.01.1

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.07.08"
+    "spack-packages": "2025.03.001"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.01.0
+    - access-om3@git.2025.01.1
   packages:
     # Main Dependencies
     access-om3-nuopc:
@@ -52,5 +52,5 @@ spack:
           - access-om3
           - access-om3-nuopc
         projections:
-          access-om3: '{name}/2025.01.0'
+          access-om3: '{name}/2025.01.1'
           access-om3-nuopc: '{name}/0.4.0-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,6 @@ spack:
     access-om3-nuopc:
       require:
         - '@git.0.4.0'
-        - +mom_symmetric
         - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
 
     # Other Dependencies


### PR DESCRIPTION
A PR to assemble changes for the next release (following 2025.01.0).

---
:rocket: The latest prerelease `access-om3/pr61-5` at 8f019e191e619b615dbcc31ac0e4ba69a74df8d0 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/61#issuecomment-2712256732 :rocket:




