### PR TITLE
Update MOM6 to latest on `mom-ocean/MOM6:main`

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.0.4.0'
+        - '@git.90d665f35e511333a30e48e48456ba5d7c05bcd4'
         - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
 
     # Other Dependencies
@@ -53,4 +53,4 @@ spack:
           - access-om3-nuopc
         projections:
           access-om3: '{name}/2025.01.1'
-          access-om3-nuopc: '{name}/0.4.0-{hash:7}'
+          access-om3-nuopc: '{name}/90d665f35e511333a30e48e48456ba5d7c05bcd4-{hash:7}'


### PR DESCRIPTION
This PR is to test updating MOM6 to the [latest version on `mom-ocean/MOM6:main`](https://github.com/ACCESS-NRI/MOM6/tree/e818ea4e792f0b85797247f955789b3c1210db8d)

---
:rocket: The latest prerelease `access-om3/pr62-1` at 4a40066189fc6f865447d0247731aae6e3e1fe02 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/62#issuecomment-2712453621 :rocket:
