### PR TITLE
Oneapi without changing spack-packages

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -43,7 +43,7 @@ spack:
 
     all:
       require:
-        - '%intel@2025.0.4'
+        - '%oneapi@2025.0.4'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.01.1
+    - access-om3@git.2025.01.2
   packages:
     # Main Dependencies
     access-om3-nuopc:
@@ -37,11 +37,14 @@ spack:
     fortranxml:
       require:
         - '@4.1.2'
+    gccruntime:
+      require:
+        - '%gcc'
 
     all:
       require:
-        - '%intel@2021.10.0'
-        - 'target=x86_64'
+        - '%intel@2025.0.4'
+        - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true
@@ -52,5 +55,5 @@ spack:
           - access-om3
           - access-om3-nuopc
         projections:
-          access-om3: '{name}/2025.01.1'
+          access-om3: '{name}/2025.01.2'
           access-om3-nuopc: '{name}/0.4.0-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -37,7 +37,7 @@ spack:
     fortranxml:
       require:
         - '@4.1.2'
-    gccruntime:
+    gcc-runtime:
       require:
         - '%gcc'
 


### PR DESCRIPTION
This tests not changing spack-pacakges at all and just building with the opeapi compiler.


---
:rocket: The latest prerelease `access-om3/pr68-3` at addf3bbb67000fe73ad71446480cb87c22b9c5c9 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/68#issuecomment-2738294076 :rocket:


