### PR TITLE
Update to cosima/access-om3 0.4.1

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.03.001"
+    "spack-packages": "2025.03.005"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,12 +6,12 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.01.1
+    - access-om3@git.2025.01.2
   packages:
     # Main Dependencies
     access-om3-nuopc:
       require:
-        - '@git.0.4.0'
+        - '@git.0.4.1'
         - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
 
     # Other Dependencies
@@ -52,5 +52,5 @@ spack:
           - access-om3
           - access-om3-nuopc
         projections:
-          access-om3: '{name}/2025.01.1'
-          access-om3-nuopc: '{name}/0.4.0-{hash:7}'
+          access-om3: '{name}/2025.01.2'
+          access-om3-nuopc: '{name}/0.4.1-{hash:7}'


### PR DESCRIPTION
Use https://github.com/COSIMA/access-om3/releases/tag/0.4.1

---
:rocket: The latest prerelease `access-om3/pr74-4` at 7d26cc382bd67af793a8acfd1711694053fcf322 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/74#issuecomment-2756628544 :rocket:



