### PR TITLE
Retry mom6-standalone+openmp

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -6,35 +6,9 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.05.000
+    - access-mom6@git.2025.02.000 ~access3 +openmp
   packages:
     # Main Dependencies
-    access3:
-      require:
-        - '@git.2025.03.0'
-        - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-    access-cice:
-      require:
-        - '@git.CICE6.6.0-1'
-        - io_type=PIO
-    access-mom6:
-      require:
-        - '@git.2025.02.000'
-        - '+asymmetric_mem'
-    access-ww3:
-      require:
-        - '@git.2025.03.0'
-    access3-share:
-      require:
-        - '@git.2025.03.0'
-
-    # Other Dependencies
-    esmf:
-      require:
-        - '@git.v8.7.0'
-    parallelio:
-      require:
-        - '@2.6.2'
     netcdf-c:
       require:
         - '@4.9.2'
@@ -48,9 +22,6 @@ spack:
     openmpi:
       require:
         - '@4.1.7'
-    fortranxml:
-      require:
-        - '@4.1.2'
     gcc-runtime:
       require:
         - '%gcc'
@@ -69,5 +40,4 @@ spack:
           - access-om3
           - access3
         projections:
-          access-om3: '{name}/2025.05.000'
-          access3: '{name}/2025.03.0-{hash:7}'
+          access-mom6: '{name}/2025.02.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,7 +18,7 @@ spack:
         - '@4.6.1'
     fms:
       require:
-        - '@git.2024.03'
+        - '@git.2025.02'
     openmpi:
       require:
         - '@4.1.7'


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-om3/pr100-2` at 49ff3bf037b6fae1204b94f879fda2b0e540e00a is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/100#issuecomment-2893858219 :rocket:

