### PR TITLE
Release 2025.05.001

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.04.002"
+    "spack-packages": "2025.06.000"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,31 +13,52 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
         - '@2025.02.001'
         - '+asymmetric_mem'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,32 +6,38 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.05.000
+    - access-om3@git.2025.05.001
   packages:
     # Main Dependencies
     access3:
       require:
-        - '@git.2025.03.0'
+        - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
     access-cice:
       require:
-        - '@git.CICE6.6.0-1'
+        - '@CICE6.6.0-3'
         - io_type=PIO
     access-mom6:
       require:
-        - '@git.2025.02.000'
+        - '@2025.02.001'
         - '+asymmetric_mem'
     access-ww3:
       require:
-        - '@git.2025.03.0'
+        - '@2025.03.0'
     access3-share:
       require:
-        - '@git.2025.03.0'
+        - '@2025.03.1'
+    access-generic-tracers:
+      require:
+        - '@git.dev-2025.05.001=development'
+    access-mocsy:
+      require:
+        - '@git.2017.12.0=gtracers'
 
     # Other Dependencies
     esmf:
       require:
-        - '@git.v8.7.0'
+        - '@git.v8.7.0=8.7.0'
     parallelio:
       require:
         - '@2.6.2'
@@ -44,7 +50,7 @@ spack:
         - '@4.6.1'
     fms:
       require:
-        - '@git.2024.03'
+        - '@git.2025.02=2025.02'
     openmpi:
       require:
         - '@4.1.7'
@@ -69,5 +75,5 @@ spack:
           - access-om3
           - access3
         projections:
-          access-om3: '{name}/2025.05.000'
-          access3: '{name}/2025.03.0-{hash:7}'
+          access-om3: '{name}/2025.05.001'
+          access3: '{name}/2025.03.1-{hash:7}'


### PR DESCRIPTION
This PR includes changes for the ACCESS-OM3 2025.05.001 release:
- [x] spack-packages 2025.05.002
- [x] access3/access3-share 2025.03.1
  - Set earth radius consistent with UM
- [x] access-cice CICE6.6.0-3
  - Add ability to write grid history file
- [x] access-mom6 2025.02.001
  - Add gtracers library to CMake build
- [x] Add access-generic-tracers git.dev-2025.05.001 and  access-mocsy git.2017.12.0
- [x] Use spack versions where sensible; explicity set spack version where gitref is necessary
- [x] Set compiler optimization flags for improved performance

---
:rocket: The latest prerelease `access-om3/pr106-3` at ed2347505e96e78187d7e9a82fa80aea7898a782 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/106#issuecomment-2933858152 :rocket:


