### PR TITLE
symmetric mom6 based on 2025.05.001 build

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,6 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - '+asymmetric_mem'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
closes https://github.com/ACCESS-NRI/ACCESS-OM3/pull/99

access-om3 with symmetric mom6 