### PR TITLE
Prerelease for testing restart checksums

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -13,51 +13,51 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,21 +14,21 @@ spack:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
         - '@2025.02.001'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
         - '@2025.03.0'
@@ -36,28 +36,28 @@ spack:
       require:
         - '@2025.03.1'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -assume nominus0 -assume nostd_minus0_rounding"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,6 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - '+asymmetric_mem'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
Yet another prerelease PR for testing compiler flag options in relation to https://github.com/ACCESS-NRI/model-config-tests/issues/155

---
:rocket: The latest prerelease `access-om3/pr111-3` at 3a97700cccc5e4404c018dfc4c8d1c3c036b1960 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/111#issuecomment-2961623187 :rocket:


