### PR TITLE
Panan Optimization

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.06.000"
+    "spack-packages": "97c26382fab997698a344b9aac364b8a4e7411df"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -77,7 +77,7 @@ spack:
         - '@4.6.1'
     fms:
       require:
-        - '@git.2025.02=2025.02'
+        - '@git.2024.03'
     openmpi:
       require:
         - '@4.1.7'

--- a/spack.yaml
+++ b/spack.yaml
@@ -21,50 +21,50 @@ spack:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,10 +13,10 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -28,10 +28,10 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
     access-ww3:
       require:
         - '@2025.03.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -21,10 +21,10 @@ spack:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-mom6:
       require:
         - '@2025.02.001'

--- a/spack.yaml
+++ b/spack.yaml
@@ -21,7 +21,7 @@ spack:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"' # flto/ipo fails for cice
         - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
         - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,58 +13,58 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,7 +13,7 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,58 +13,58 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,58 +13,58 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"' # flto/ipo fails for cice
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
         - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
         - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     parallelio:
       require:
         - '@2.6.2'
@@ -77,7 +77,7 @@ spack:
         - '@4.6.1'
     fms:
       require:
-        - '@git.2024.03'
+        - '@git.2025.02=2025.02'
     openmpi:
       require:
         - '@4.1.7'
@@ -90,7 +90,7 @@ spack:
 
     all:
       require:
-        - '%intel@2021.10.0'
+        - '%oneapi@2025.0.4'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -80,7 +80,7 @@ spack:
         - '@git.2025.02=2025.02'
     openmpi:
       require:
-        - '@4.1.7'
+        - '@4.1.5'
     fortranxml:
       require:
         - '@4.1.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,58 +13,58 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-mom6:
       require:
         - '@2025.02.001'
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
         - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,51 +13,58 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,10 +13,10 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -28,43 +28,43 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -21,7 +21,7 @@ spack:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
         - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
         - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,58 +13,58 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -31,7 +31,7 @@ spack:
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
     access-ww3:
       require:
         - '@2025.03.0'
@@ -41,21 +41,21 @@ spack:
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
 
     # Other Dependencies
     esmf:
@@ -64,7 +64,7 @@ spack:
         - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
         - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,10 +13,10 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -28,43 +28,43 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
     parallelio:
       require:
         - '@2.6.2'
@@ -90,7 +90,7 @@ spack:
 
     all:
       require:
-        - '%oneapi@2025.0.4'
+        - '%intel@2021.10.0'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -90,7 +90,7 @@ spack:
 
     all:
       require:
-        - '%oneapi@2025.0.4'
+        - '%oneapi@2025.2.0'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,6 +16,7 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - +mom_symmetric
     access-cice:
       require:
         - '@CICE6.6.0-3'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,10 +13,10 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto -fuse-ld=lld"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -28,43 +28,43 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto -fuse-ld=lld"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto -fuse-ld=lld"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto -fuse-ld=lld"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto -fuse-ld=lld"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -qopt-prefetch -flto -fuse-ld=lld"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,58 +13,58 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -qopt-prefetch"'
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -qopt-prefetch"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld -qopt-prefetch"'
     parallelio:
       require:
         - '@2.6.2'
@@ -90,7 +90,7 @@ spack:
 
     all:
       require:
-        - '%intel@2021.10.0'
+        - '%oneapi@2025.0.4'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,10 +13,10 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo -"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -28,43 +28,43 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'cxxflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
+        - 'ldflags="-march=cascadelake -mtune=sapphirerapids -unroll -O3 -ipo"'
     parallelio:
       require:
         - '@2.6.2'
@@ -90,7 +90,7 @@ spack:
 
     all:
       require:
-        - '%oneapi@2025.0.4'
+        - '%intel@2021.10.0'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,6 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - +mom_symmetric
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -27,7 +26,6 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - '+asymmetric_mem'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
This is picking up from @minghangli-uni's work for helping optimize @claireyung's panan runs in preparation for her 10-year run.

Live results (5-day run):

| Build | SUs | comment |
| --- | --- | --- |
| `pr75-1` best of 3 | 3035.88 | This is Helen's build where slowness was first noted |
| `pr113-2` best of 1 | 2931.41 | `pr113-2` has a few changes: ifx instead of ifort, `-{march,mtune}=sapphirerapids` and spack build changes. I was a little worried since sometimes `ifx` can be a lot slower than `ifort`. |
| `pr113-3` best of 1 | 2935.11 | adds `-O3`. Not much difference. This is because `-O3` isn't registered in most of our builds as `-O2` is hardcoded and placed *after* spack user-supplied `fflags`. |
| `pr113-4` best of 1 | 2992.43 | changes `-march=sapphirerapids` to `-march=cascadelake` for compatibility with cascadelake nodes. A bit of a slow down is not surprising but still disappointing. |
| `pr113-10` best of 2 | 3028.48 | Adds `-flto -fuse-ld=lld` to everything except CICE6. Disappointing result. |
| `pr113-20` best of 1 | 2957.30 | Adds `-qopt-prefetch` to everything, resulting in a small improvement. |
| `pr113-21` best of 1 | 2928.64 | Makes sure `-O3` takes precedence. Got a small boost. |
| `pr113-25` best of 1 | 2957.30 | Removes `-flto` to see if performance is better (since previous `-flto` result showed a slowdown). Does actually slow down, so would prefer to keep it. |
| `pr113-26` best of 1 | 2947.13 | Uses `oneapi@2025.2.0` after manodeep's encouraging findings. Not much difference. |
| `pr113-27` best of 1 | 2887.04 | Adds back `-flto` Which seemed to help a decent amount. |

Current most preferred: `pr113-27` for backwards compatibility.

---
:rocket: The latest prerelease `access-om3/pr113-3` at 4899d3f2ac356dce550875f4c07e590822791953 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/113#issuecomment-3022074264 :rocket:




---
:rocket: The latest prerelease `access-om3/pr113-4` at 89258cb8a6e67fec9b3bba359220f8695e90ba84 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/113#issuecomment-3025892274 :rocket:


---
:rocket: The latest prerelease `access-om3/pr113-14` at 8f4870d96f5b7b69ca944ed9167b99eeb3eb33ef is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/113#issuecomment-3029551152 :rocket:











---
:rocket: The latest prerelease `access-om3/pr113-18` at 0377ee8bed0f7f9a19ca5580ad9cca9156417bd4 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/113#issuecomment-3030798688 :rocket:





---
:rocket: The latest prerelease `access-om3/pr113-20` at 0377ee8bed0f7f9a19ca5580ad9cca9156417bd4 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/113#issuecomment-3033991009 :rocket:



---
:rocket: The latest prerelease `access-om3/pr113-21` at f176d6b27acbb4d72806ed5f75f194ccb0ee2c54 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/113#issuecomment-3034626300 :rocket:


---
:rocket: The latest prerelease `access-om3/pr113-22` at 6d8dab52b75aa474b70652878147dd3a312498c5 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/113#issuecomment-3035576954 :rocket:


---
:rocket: The latest prerelease `access-om3/pr113-27` at 11938bd22ec34da145839a922f3a90b08c1f6bf4 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/113#issuecomment-3043209428 :rocket:






---
:rocket: The latest prerelease `access-om3/pr113-28` at 77933297b40bb8c788e8649a6a2adc4f275ef033 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/113#issuecomment-3082089827 :rocket:
