### PR TITLE
Update access-generic-tracers to dev-2025.06.002

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -41,7 +41,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.05.001=development'
+        - '@git.dev-2025.06.000=development'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -41,7 +41,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.06.001=development'
+        - '@git.dev-2025.06.002=development'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -41,7 +41,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.06.000=development'
+        - '@git.dev-2025.06.001=development'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
As per title

---
:rocket: The latest prerelease `access-om3/pr116-3` at dd209218f0183b248b94c3640d277bb03af1b9a1 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/116#issuecomment-3004805000 :rocket:


