### PR TITLE
Add WW3 utils to path

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "d1efdb5f9a52efe6f905e52341788468d04a58bc"
+    "spack-packages": "2025.06.000"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.06.000"
+    "spack-packages": "747e2ffd42dc95513dfe97fcbe66a52a5ad13112"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "747e2ffd42dc95513dfe97fcbe66a52a5ad13112"
+    "spack-packages": "d1efdb5f9a52efe6f905e52341788468d04a58bc"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -93,8 +93,9 @@ spack:
     default:
       tcl:
         include:
-          - access-om3
           - access3
+          - access-om3
+          - access-ww3
         projections:
           access-om3: '{name}/2025.05.001'
           access3: '{name}/2025.03.1-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -93,9 +93,10 @@ spack:
     default:
       tcl:
         include:
-          - access3
           - access-om3
+          - access3
           - access-ww3
         projections:
           access-om3: '{name}/2025.05.001'
           access3: '{name}/2025.03.1-{hash:7}'
+          access-ww3: '{name}/2025.03.0-{hash:7}'


### PR DESCRIPTION
Fixes #118 
---
:rocket: The latest prerelease `access-om3/pr117-3` at ca0dfad73f0a5b4ac082b0b0de03be73fc1287f3 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/117#issuecomment-3006604191 :rocket:




---
:rocket: The latest prerelease `access-om3/pr117-5` at 63b205f83b48b7a0bb185ec57e4af1771d1d2093 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/117#issuecomment-3006777037 :rocket:

