### PR TITLE
MOM6 symmetric with updated MOM6 version

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.06.000"
+    "spack-packages": "97c26382fab997698a344b9aac364b8a4e7411df"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,7 +18,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-        - '@CICE6.6.0-3'
+        - '@git.fe521f93dda96d2e7a7fed1d2a05cdab3c08170b'
         - io_type=PIO
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,6 +16,7 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '%oneapi@2025.0.4'
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -23,6 +24,7 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '%oneapi@2025.0.4'
     access-mom6:
       require:
         - '@git.f20b0e150b0273b128ebd0e63ee3238755aa0986=2025.02.001'
@@ -33,12 +35,14 @@ spack:
     access-ww3:
       require:
         - '@2025.03.0'
+        - '%oneapi@2025.0.4'
     access3-share:
       require:
         - '@2025.03.1'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '%oneapi@2025.0.4'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
@@ -61,32 +65,38 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '%oneapi@2025.0.4'
     parallelio:
       require:
         - '@2.6.2'
+        - '%oneapi@2025.0.4'
     netcdf-c:
       require:
         - '@4.9.2'
         - build_system=cmake build_type=RelWithDebInfo
+        - '%oneapi@2025.0.4'
     netcdf-fortran:
       require:
         - '@4.6.1'
+        - '%oneapi@2025.0.4'
     fms:
       require:
         - '@git.2025.02=2025.02'
+        - '%oneapi@2025.0.4'
     openmpi:
       require:
         - '@4.1.7'
+        - '%oneapi@2025.0.4'
     fortranxml:
       require:
         - '@4.1.2'
+        - '%oneapi@2025.0.4'
     gcc-runtime:
       require:
         - '%gcc'
 
     all:
       require:
-        - '%oneapi@2025.0.4'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -71,6 +71,7 @@ spack:
     fms:
       require:
         - '@git.2025.02=2025.02'
+        - '%oneapi@2025.0.4'
     openmpi:
       require:
         - '@4.1.7'

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@921b3402466fd0a24ab8c409bbef8fb721f483bd'
+        - '@git.921b3402466fd0a24ab8c409bbef8fb721f483bd=2025.02.001'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -83,7 +83,7 @@ spack:
 
     all:
       require:
-        - '%oneapi@2025.0.4'
+        - '%oneapi@2025.1.1'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -39,7 +39,6 @@ spack:
       require:
         - '@2025.03.0'
         - '%oneapi@2025.0.4'
-        - build_type=Debug
     access3-share:
       require:
         - '@2025.03.1'
@@ -55,7 +54,6 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.1.1'
-        - build_type=Debug
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
@@ -63,7 +61,6 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.1.1'
-        - build_type=Debug
 
     # Other Dependencies
     esmf:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@git.921b3402466fd0a24ab8c409bbef8fb721f483bd=2025.02.001'
+        - '@git.f20b0e150b0273b128ebd0e63ee3238755aa0986=2025.02.001'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
         - '%oneapi@2025.0.4'
     access-mom6:
       require:
-        - '@git.07b59848401c38e30eda920f8a7f4fb4aa229b82=2025.02.001'
+        - '@git.a0f364934d76fbf3972ce6a00c960d33ef3e1981=2025.02.001'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,7 +17,7 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.0.4'
-        - build_type=Debug
+        - fflags="-O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -26,7 +26,7 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.0.4'
-        - build_type=Debug
+        - fflags="-O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"
     access-mom6:
       require:
         - '@git.f6ab4fdaa8e2f94dfecbfd546355ec0fb98c2738=2025.02.001'
@@ -34,7 +34,7 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.1.1'
-        - build_type=Debug
+        - fflags="-O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"
     access-ww3:
       require:
         - '@2025.03.0'
@@ -46,7 +46,7 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.0.4'
-        - build_type=Debug
+        - fflags="-O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
@@ -73,7 +73,6 @@ spack:
     parallelio:
       require:
         - '@2.6.2'
-        - build_type=RelWithDebInfo
         - '%oneapi@2025.0.4'
     netcdf-c:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
         - '%oneapi@2025.0.4'
     access-mom6:
       require:
-        - '@git.a0f364934d76fbf3972ce6a00c960d33ef3e1981=2025.02.001'
+        - '@git.f6ab4fdaa8e2f94dfecbfd546355ec0fb98c2738=2025.02.001'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
         - '%oneapi@2025.0.4'
     access-mom6:
       require:
-        - '@git.f20b0e150b0273b128ebd0e63ee3238755aa0986=2025.02.001'
+        - '@git.07b59848401c38e30eda920f8a7f4fb4aa229b82=2025.02.001'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,6 +16,7 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '%oneapi@2025.0.4'
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -23,6 +24,7 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '%oneapi@2025.0.4'
     access-mom6:
       require:
         - '@git.f20b0e150b0273b128ebd0e63ee3238755aa0986=2025.02.001'
@@ -33,24 +35,28 @@ spack:
     access-ww3:
       require:
         - '@2025.03.0'
+        - '%oneapi@2025.0.4'
     access3-share:
       require:
         - '@2025.03.1'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '%oneapi@2025.0.4'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '%oneapi@2025.1.1'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '%oneapi@2025.1.1'
 
     # Other Dependencies
     esmf:
@@ -59,32 +65,39 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '%oneapi@2025.0.4'
     parallelio:
       require:
         - '@2.6.2'
+        - '%oneapi@2025.0.4'
     netcdf-c:
       require:
         - '@4.9.2'
         - build_system=cmake build_type=RelWithDebInfo
+        - '%oneapi@2025.0.4'
     netcdf-fortran:
       require:
         - '@4.6.1'
+        - '%oneapi@2025.0.4'
     fms:
       require:
         - '@git.2025.02=2025.02'
+        - '%oneapi@2025.0.4'
     openmpi:
       require:
         - '@4.1.7'
+        - '%oneapi@2025.0.4'
     fortranxml:
       require:
         - '@4.1.2'
+        - '%oneapi@2025.0.4'
     gcc-runtime:
       require:
         - '%gcc'
+        - '%oneapi@2025.0.4'
 
     all:
       require:
-        - '%oneapi@2025.0.4'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,6 +29,7 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '%oneapi@2025.1.1'
     access-ww3:
       require:
         - '@2025.03.0'
@@ -71,7 +72,6 @@ spack:
     fms:
       require:
         - '@git.2025.02=2025.02'
-        - '%oneapi@2025.0.4'
     openmpi:
       require:
         - '@4.1.7'
@@ -84,7 +84,7 @@ spack:
 
     all:
       require:
-        - '%oneapi@2025.1.1'
+        - '%oneapi@2025.0.4'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,6 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '%oneapi@2025.0.4'
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -24,7 +23,6 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '%oneapi@2025.0.4'
     access-mom6:
       require:
         - '@git.f20b0e150b0273b128ebd0e63ee3238755aa0986=2025.02.001'
@@ -35,14 +33,12 @@ spack:
     access-ww3:
       require:
         - '@2025.03.0'
-        - '%oneapi@2025.0.4'
     access3-share:
       require:
         - '@2025.03.1'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '%oneapi@2025.0.4'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
@@ -65,38 +61,32 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '%oneapi@2025.0.4'
     parallelio:
       require:
         - '@2.6.2'
-        - '%oneapi@2025.0.4'
     netcdf-c:
       require:
         - '@4.9.2'
         - build_system=cmake build_type=RelWithDebInfo
-        - '%oneapi@2025.0.4'
     netcdf-fortran:
       require:
         - '@4.6.1'
-        - '%oneapi@2025.0.4'
     fms:
       require:
         - '@git.2025.02=2025.02'
-        - '%oneapi@2025.0.4'
     openmpi:
       require:
         - '@4.1.7'
-        - '%oneapi@2025.0.4'
     fortranxml:
       require:
         - '@4.1.2'
-        - '%oneapi@2025.0.4'
     gcc-runtime:
       require:
         - '%gcc'
 
     all:
       require:
+        - '%oneapi@2025.0.4'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -94,7 +94,6 @@ spack:
     gcc-runtime:
       require:
         - '%gcc'
-        - '%oneapi@2025.0.4'
 
     all:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,6 +16,7 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - +mom_symmetric
     access-cice:
       require:
         - '@CICE6.6.0-3'

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,7 +18,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-        - '@git.e2efd7b905a0c042ec0083c53469fd2c688251e4'
+        - '@git.83d1f71749889a4394aecbf204ebd2b9bdbf1440'
         - io_type=PIO
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,7 +18,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-        - '@git.fe521f93dda96d2e7a7fed1d2a05cdab3c08170b'
+        - '@git.e2efd7b905a0c042ec0083c53469fd2c688251e4'
         - io_type=PIO
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
@@ -54,7 +54,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - '@git.v8.7.0=8.7.0'
+        - '@git.v8.7.0=8.7.0 /cj6ae3p'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,6 +17,7 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.0.4'
+        - build_type=Debug
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -25,6 +26,7 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.0.4'
+        - build_type=Debug
     access-mom6:
       require:
         - '@git.f6ab4fdaa8e2f94dfecbfd546355ec0fb98c2738=2025.02.001'
@@ -32,10 +34,12 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.1.1'
+        - build_type=Debug
     access-ww3:
       require:
         - '@2025.03.0'
         - '%oneapi@2025.0.4'
+        - build_type=Debug
     access3-share:
       require:
         - '@2025.03.1'
@@ -43,6 +47,7 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.0.4'
+        - build_type=Debug
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
@@ -50,6 +55,7 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.1.1'
+        - build_type=Debug
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
@@ -57,6 +63,7 @@ spack:
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - '%oneapi@2025.1.1'
+        - build_type=Debug
 
     # Other Dependencies
     esmf:
@@ -69,6 +76,7 @@ spack:
     parallelio:
       require:
         - '@2.6.2'
+        - build_type=RelWithDebInfo
         - '%oneapi@2025.0.4'
     netcdf-c:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,54 +13,43 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '%oneapi@2025.0.4'
-        - fflags="-O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '%oneapi@2025.0.4'
-        - fflags="-O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"
     access-mom6:
       require:
         - '@git.f6ab4fdaa8e2f94dfecbfd546355ec0fb98c2738=2025.02.001'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '%oneapi@2025.1.1'
-        - fflags="-O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"
     access-ww3:
       require:
         - '@2025.03.0'
-        - '%oneapi@2025.0.4'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '%oneapi@2025.0.4'
-        - fflags="-O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"
     access-generic-tracers:
       require:
-        - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@git.dev-2025.06.002=development'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '%oneapi@2025.1.1'
     access-mocsy:
       require:
-        - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@git.2025.07.000=gtracers'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O0 -g -check bounds -check pointers -fpe0 -check noarg_temp_created"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '%oneapi@2025.1.1'
 
     # Other Dependencies
     esmf:
@@ -69,38 +58,32 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '%oneapi@2025.0.4'
     parallelio:
       require:
         - '@2.6.2'
-        - '%oneapi@2025.0.4'
     netcdf-c:
       require:
         - '@4.9.2'
         - build_system=cmake build_type=RelWithDebInfo
-        - '%oneapi@2025.0.4'
     netcdf-fortran:
       require:
         - '@4.6.1'
-        - '%oneapi@2025.0.4'
     fms:
       require:
         - '@git.2025.02=2025.02'
-        - '%oneapi@2025.0.4'
     openmpi:
       require:
         - '@4.1.7'
-        - '%oneapi@2025.0.4'
     fortranxml:
       require:
         - '@4.1.2'
-        - '%oneapi@2025.0.4'
     gcc-runtime:
       require:
         - '%gcc'
 
     all:
       require:
+        - '%oneapi@2025.2.0'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@2025.02.001'
+        - '@921b3402466fd0a24ab8c409bbef8fb721f483bd'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,6 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - +mom_symmetric
     access-cice:
       require:
         - '@CICE6.6.0-3'
@@ -27,7 +26,6 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - '+asymmetric_mem'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
 *do not merge!*

Updated [MOM6 version](https://github.com/ACCESS-NRI/MOM6/tree/921b3402466fd0a24ab8c409bbef8fb721f483bd) includes recent mom-ocean merge from GFDL and associated ice shelf pressure gradient fixes


---
:rocket: The latest prerelease `access-om3/pr120-19` at b751c08461cc95eb330b8b504aae0bd1f24a3c7e is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/120#issuecomment-3082064434 :rocket:


















