### PR TITLE
Add -O3 and dougie's MOM6 branch

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -25,11 +25,11 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@2025.02.001'
+        - '@git.5c379e2cfcedaf6b5010defbfff888428229bf8c=2025.02.001'
         - '+asymmetric_mem'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-ww3:
       require:
         - '@2025.03.0'


### PR DESCRIPTION
don't merge!

This is just to test that dougie's MOM6 cmake changes propagates -O3 in the right order in the compilation.

---
:rocket: The latest prerelease `access-om3/pr121-1` at c32b1af66ee9210097205af57e1ebeb4dcace17f is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/121#issuecomment-3030475584 :rocket:
