### PR TITLE
Panan Optimization using ifort

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,6 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - '+asymmetric_mem'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
@@ -84,7 +83,7 @@ spack:
 
     all:
       require:
-        - '%oneapi@2025.0.4'
+        - '%intel@2021.10.0'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,7 +29,7 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -ipo"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -ipo"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -ipo"'
-        - 'ldflags="-march=sapphirerapids -mtune-sapphirerapids -unroll -ipo"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -ipo"'
     access-ww3:
       require:
         - '@2025.03.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,9 +26,10 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -ipo"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -ipo"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -ipo"'
+        - 'ldflags="-march=sapphirerapids -mtune-sapphirerapids -unroll -O2 -ipo"' # Currently stuck to using -O2
     access-ww3:
       require:
         - '@2025.03.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,7 +29,7 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -ipo"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -ipo"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -ipo"'
-        - 'ldflags="-march=sapphirerapids -mtune-sapphirerapids -unroll -O2 -ipo"' # Currently stuck to using -O2
+        - 'ldflags="-march=sapphirerapids -mtune-sapphirerapids -unroll -ipo"'
     access-ww3:
       require:
         - '@2025.03.0'


### PR DESCRIPTION
Don't merge!

This is similar to https://github.com/ACCESS-NRI/ACCESS-OM3/pull/113 except investigating ifort more thoroughly.

| Build | SUs | comment |
| --- | --- | --- |
| `pr113-2` best of 1 | 2931.41 | Base case - includes `-march=sapphirerapids -mtune=sapphirerapids -unroll` |
| `pr122-1` best of 1 | 2926.79 | Uses `ifort` instead of `ifx` with same flags. Not significantly different. |
| `pr122-4` best of 1 | 2924.02 | Uses `-ipo` on MOM6 only. Not significantly different. |

---
:rocket: The latest prerelease `access-om3/pr122-4` at 88576f35491ee6a401c1f78e3882c3c6fd6010b7 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/122#issuecomment-3034154408 :rocket:



