### PR TITLE
Test Hurshula's default flag handler

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.06.000"
+    "spack-packages": "97c26382fab997698a344b9aac364b8a4e7411df"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,52 +13,52 @@ spack:
       require:
         - '@2025.03.1'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-cice:
       require:
         - '@CICE6.6.0-3'
         - io_type=PIO
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-mom6:
       require:
         - '@2025.02.001'
         - '+asymmetric_mem'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-ww3:
       require:
         - '@2025.03.0'
     access3-share:
       require:
         - '@2025.03.1'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-generic-tracers:
       require:
         - '@git.dev-2025.05.001=development'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-mocsy:
       require:
         - '@git.2017.12.0=gtracers'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
 
     # Other Dependencies
     esmf:
       require:
         - '@git.v8.7.0=8.7.0'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,6 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - '+asymmetric_mem'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'


### PR DESCRIPTION
Don't commit!

This is testing that -O3 is applied correctly in compilation cmds when using hurshala's default flag handler https://github.com/ACCESS-NRI/spack-packages/tree/use-default-flag-handler.

---
:rocket: The latest prerelease `access-om3/pr123-2` at a29f829cf0f08a457e67eae94612200b9a432dea is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/123#issuecomment-3034286430 :rocket:

