### PR TITLE
Build with FMS yaml support

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -72,12 +72,16 @@ spack:
     fms:
       require:
         - '@git.2025.02=2025.02'
+        - '+yaml'
     openmpi:
       require:
         - '@4.1.7'
     fortranxml:
       require:
         - '@4.1.2'
+    libyaml:
+      require:
+        - '@0.2.5'
     gcc-runtime:
       require:
         - '%gcc'


### PR DESCRIPTION
FMS>=2021.04 optionally supports yaml format input files (diag table, field table, data table). This PR builds ACCESS-OM3 with yaml support enabled in FMS.

---
:rocket: The latest prerelease `access-om3/pr126-1` at d89c46c8cd5810571490c590c97960a9431dd00d is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/126#issuecomment-3102438619 :rocket:
