### PR TITLE
Use patched spack with esmf8.7.0

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
-    "spack": "0.22",
+    "spack": "7d18920bf93312a3d9ce3c563acf11e7eaddfd1f",
     "spack-packages": "2025.06.000"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -55,7 +55,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - '@git.v8.7.0=8.7.0'
+        - '@8.7.0'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
Demonstration for https://github.com/ACCESS-NRI/spack/pull/13

---
:rocket: The latest prerelease `access-om3/pr129-1` at b37edaf6972714f0181f324ccf23c2f74377bde5 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/129#issuecomment-3142141965 :rocket:
