### PR TITLE
2025.08.000 Release

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.06.000"
+    "spack-packages": "2025.08.000"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.08.002"
+    "spack-packages": "2025.08.003"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.08.000"
+    "spack-packages": "2025.08.002"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -40,7 +40,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-        - '@2025.07.002'
+        - '@2025.08.000'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@git.7d90a4b1a574b651da30f23777af2481f4ed8022=2025.08.000'
+        - '@2025.07.000'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@2025.08.000'
+        - '@git.7d90a4b1a574b651da30f23777af2481f4ed8022=2025.08.000'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -54,7 +54,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - '@git.v8.7.0=8.7.0'
+        - '@8.7.0'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -53,10 +53,11 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - ''/f6hz7wz''  # Same as '@8.7.0' but reduces number of rebuilds 
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@8.7.0'
+        - '/f6hz7wz' # Same as '@8.7.0' but reduces number of rebuilds 
+        # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -70,7 +70,7 @@ spack:
         - '@4.6.1'
     fms:
       require:
-        - '@git.2025.02=2025.02'
+        - '@2025.02'
     openmpi:
       require:
         - '@4.1.7'

--- a/spack.yaml
+++ b/spack.yaml
@@ -53,7 +53,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - '@8.7.0 /f6hz7wz'
+        - '@8.7.0 ^/f6hz7wz'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -53,7 +53,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - '@8.7.0'
+        - '@8.7.0 /f6hz7wz'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
     access3:
       require:
         - '@2025.08.000'
-        - configurations=MOM6-CICE6,MOM6-CICE6-WW3
+        - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -54,10 +54,9 @@ spack:
     esmf:
       require:
         - '@8.7.0'
-        - '/f6hz7wz' # Same as '@8.7.0' but reduces number of rebuilds 
-        # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,48 +6,48 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.05.001
+    - access-om3@git.2025.08.000
   packages:
     # Main Dependencies
     access3:
       require:
-        - '@2025.03.1'
+        - '@2025.08.000'
         - configurations=MOM6-CICE6,MOM6-CICE6-WW3
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-        - '@CICE6.6.0-3'
+        - '@CICE6.6.1-0'
         - io_type=PIO
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@2025.02.001'
+        - '@2025.08.000'
         - '+asymmetric_mem'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
-        - '@2025.03.0'
+        - '@2025.08.000'
     access3-share:
       require:
-        - '@2025.03.1'
+        - '@2025.08.000'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-        - '@git.dev-2025.05.001=development'
+        - '@2025.07.002'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mocsy:
       require:
-        - '@git.2017.12.0=gtracers'
+        - '@2025.07.002'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -53,7 +53,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - '/f6hz7wz'  # Same as '@8.7.0' but reduces number of rebuilds 
+        - "/f6hz7wz"  # Same as '@8.7.0' but reduces number of rebuilds 
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -53,7 +53,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - "/f6hz7wz"  # Same as '@8.7.0' but reduces number of rebuilds 
+        - '"/f6hz7wz"'  # Same as '@8.7.0' but reduces number of rebuilds 
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -53,7 +53,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - '@8.7.0 ^/f6hz7wz'
+        - '/f6hz7wz'  # Same as '@8.7.0' but reduces number of rebuilds 
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -53,7 +53,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - '"/f6hz7wz"'  # Same as '@8.7.0' but reduces number of rebuilds 
+        - ''/f6hz7wz''  # Same as '@8.7.0' but reduces number of rebuilds 
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -70,7 +70,7 @@ spack:
         - '@4.6.1'
     fms:
       require:
-        - '@2025.02'
+        - '@2025.03'
     openmpi:
       require:
         - '@4.1.7'

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,6 @@ spack:
     access-mom6:
       require:
         - '@2025.08.000'
-        - '+asymmetric_mem'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
@@ -71,6 +70,7 @@ spack:
     fms:
       require:
         - '@2025.03'
+        - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:
         - '@4.1.7'

--- a/spack.yaml
+++ b/spack.yaml
@@ -82,7 +82,7 @@ spack:
         - '%gcc'
     all:
       require:
-        - '%oneapi@2025.0.4'
+        - '%oneapi@2025.2.0'
         - 'target=x86_64_v4'
   view: true
   concretizer:


### PR DESCRIPTION
New release with updates to all upstream components - as noted in https://github.com/ACCESS-NRI/access-om3-configs/issues/632

---
:rocket: The latest prerelease `access-om3/pr138-29` at 2807b30d0535da00574a0da09075e287f98a1e74 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/138#issuecomment-3236149348 :rocket:



















