### PR TITLE
Prereleases with Angus' MOM6 adaptive grid coordinate

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -26,6 +26,7 @@ spack:
     access-mom6:
       require:
         - '@git.eac1adfc582a771b2359d829bda343487bb5b298=2025.02.001'
+        - '+asymmetric_mem'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@git.97f2f08287b1cde333c5ea9fc1f566be1947adfd=2025.02.001'
+        - '@git.eac1adfc582a771b2359d829bda343487bb5b298=2025.02.001'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@2025.02.001'
+        - '@git.97f2f08287b1cde333c5ea9fc1f566be1947adfd=2025.02.001'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -26,7 +26,6 @@ spack:
     access-mom6:
       require:
         - '@2025.02.001'
-        - '+asymmetric_mem'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
This PR is to produce prerelease deployments of ACCESS-OM3 with @angus-g's [MOM6 adaptive grid (AG) coordinate](https://github.com/ACCESS-NRI/MOM6/pull/25).

The development of the AG coordinate has focused on MOM symmetric memory mode. However ACCESS-OM3 deployments/configurations use asymmetric memory. The plan at this point is to:

1. deploy a version of ACCESS-OM3 that is identical to 2025.05.001 (as used in the 25km 1.0-beta release), except use MOM6 symmetric memory. ADDED: deployed as [`access-om3/pr140-2`](https://github.com/ACCESS-NRI/ACCESS-OM3/pull/140#issuecomment-3186446131)
2. deploy a version of ACCESS-OM3 that is identical to 2025.05.001, except use MOM6 symmetric memory and include the MOM6 AG changes. ADDED: deployed as [`access-om3/pr140-5`](https://github.com/ACCESS-NRI/ACCESS-OM3/pull/140#issuecomment-3188143308)
3. check whether the deployment from 1:
  a. is reproducible across restarts
  b. reproduces the existing 25km beta release control run

If 3a fails, we'll need to rethink.
If 3b:
 - passes: Angus can use the existing 25km beta control run for the z-star comparison
 - fails: Angus will need to rerun the 25km beta release config using 1. (or 2.) to create the required z-star data.

---
:rocket: The latest prerelease `access-om3/pr140-5` at e606bc417aae77f3ae4d5fecad24a830508e911b is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/140#issuecomment-3188143308 :rocket:


---
:rocket: The latest prerelease `access-om3/pr140-7` at 379a065e46bfe42fd3970d182aa42563616bfce4 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/140#issuecomment-4440098459 :rocket:

