### PR TITLE
Prerelease ACCESS-OM3@2025.08.000 with WOMBAT legacy

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -40,7 +40,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-        - '@2025.08.000'
+        - '@2024.08.001'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
The prerelease in this PR is for use with the regional WOMBAT configurations currently being developed. 

---
:rocket: The latest prerelease `access-om3/pr144-1` at e4cf8571d99baeccc022aec2b1e15447d5e53af8 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/144#issuecomment-3243723416 :rocket:
