### PR TITLE
Setup new spack build for CM3 libraries

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "b10ec6c89dd2e69a83e7a0ddeba76e61846180da"
+    "spack-packages": "3cdc83b846c18647e4ac1e213bfb092fbd6fb5ef"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "3cdc83b846c18647e4ac1e213bfb092fbd6fb5ef"
+    "spack-packages": "b10ec6c89dd2e69a83e7a0ddeba76e61846180da"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "b10ec6c89dd2e69a83e7a0ddeba76e61846180da"
+    "spack-packages": "a6d347baf3baa316744708d6c4cc8da024fc3faa"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "a6d347baf3baa316744708d6c4cc8da024fc3faa"
+    "spack-packages": "01602e9d215520e88cf3b8f64162bd0406dbcddb"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.08.003"
+    "spack-packages": "b10ec6c89dd2e69a83e7a0ddeba76e61846180da"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.08.001 ^gcom@8.0
+    - access-om3@git.2025.08.001
   packages:
     # Main Dependencies
     access3:
@@ -66,6 +66,9 @@ spack:
     gcc-runtime:
       require:
         - '%gcc'
+    gcom:
+      require:
+        - '@8.0'
     all:
       require:
         - '%intel@2021.10.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,12 +7,13 @@
 spack:
   specs:
     - access-om3@git.2025.08.001
+    - gcom@8.0
   packages:
     # Main Dependencies
     access3:
       require:
         - '@git.870d7a45d5f0fbad6241de1748b9533e603f9bd2'
-        - configurations=MOM6-CICE6-UM13
+        - configurations=MOM6-CICE6
         # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
@@ -66,9 +67,6 @@ spack:
     gcc-runtime:
       require:
         - '%gcc'
-    gcom:
-      require:
-       - '@8.0'
     all:
       require:
         - '%intel@2021.10.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,8 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.08.001
-    - gcom@8.0
+    - access-om3@git.2025.08.001 ^gcom@8.0
   packages:
     # Main Dependencies
     access3:

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,14 +11,14 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.870d7a45d5f0fbad6241de1748b9533e603f9bd2'
+        - '@git.ff61afbb87ff84e948e60bf732262658bef46c96'
         - configurations=MOM6-CICE6
         # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-        - '@git.f2ccc1c71ccc1f01d552d72e9f6a7e4085cc583c'
+        - '@git.bd38883b7bb8f1c48a525c1172085acd82402227'
         - io_type=PIO
         - driver=access/cmeps
         # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
@@ -32,7 +32,7 @@ spack:
         # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access3-share:
       require:
-        - '@git.870d7a45d5f0fbad6241de1748b9533e603f9bd2'
+        - '@git.ff61afbb87ff84e948e60bf732262658bef46c96'
         # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,8 +11,8 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.ff9e5433cf69e522457bbc07a24c9b4a44c40c02'
-        - configurations=MOM6-CICE6
+        - '@git.870d7a45d5f0fbad6241de1748b9533e603f9bd2'
+        - configurations=MOM6-CICE6-UM13
         # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
@@ -32,7 +32,7 @@ spack:
         # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access3-share:
       require:
-        - '@git.ff9e5433cf69e522457bbc07a24c9b4a44c40c02'
+        - '@git.870d7a45d5f0fbad6241de1748b9533e603f9bd2'
         # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,52 +11,38 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@2025.08.000'
-        - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@git.ff9e5433cf69e522457bbc07a24c9b4a44c40c02'
+        - configurations=MOM6-CICE6
+        # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-        - '@CICE6.6.1-0'
+        - '@git.f2ccc1c71ccc1f01d552d72e9f6a7e4085cc583c'
         - io_type=PIO
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - driver=access/cmeps
+        # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@2025.07.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-    access-ww3:
-      require:
-        - '@2025.08.000'
+        - '@2025.02.000'
+        # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access3-share:
       require:
-        - '@2025.08.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-    access-generic-tracers:
-      require:
-        - '@2025.08.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-    access-mocsy:
-      require:
-        - '@2025.07.002'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@git.ff9e5433cf69e522457bbc07a24c9b4a44c40c02'
+        # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     # Other Dependencies
     esmf:
       require:
         - '@8.7.0'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        # - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     parallelio:
       require:
         - '@2.6.2'
@@ -69,8 +55,8 @@ spack:
         - '@4.6.1'
     fms:
       require:
-        - '@2025.03'
-        - 'cppflags="-DMAXFIELDMETHODS_=600"'
+        - '@git.2024.03'
+        # - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:
         - '@4.1.7'
@@ -80,10 +66,42 @@ spack:
     gcc-runtime:
       require:
         - '%gcc'
+    gcom:
+      require:
+       - '@8.0'
     all:
       require:
-        - '%oneapi@2025.2.0'
-        - 'target=x86_64_v4'
-  view: true
+        - '%intel@2021.10.0'
+        - 'target=x86_64'
   concretizer:
     unify: true
+
+
+  modules:
+    prefix_inspections:
+      bin:
+       - PATH
+      lib:
+       - LIBRARY_PATH
+       - LD_LIBRARY_PATH
+      lib64:
+       - LIBRARY_PATH
+       - LD_LIBRARY_PATH
+      include:
+       - FPATH
+
+    default:
+      tcl:
+        include:
+          - access-om3
+          - access-mom6
+          - access-cice
+          - access3-share
+          - esmf
+          - fms
+          - parallelio
+          - fortranxml
+          - gcom
+          - openmpi
+          - netcdf-c
+          - netcdf-fortran


### PR DESCRIPTION
Returning to the work started in https://github.com/ACCESS-NRI/ACCESS-OM3/pull/79 for getting the spack build of OM3 libraries working for CM3.

Currently focusing on cleaning everything up, and ideally we I'll get to:
- All code versions using tags
- Use the main branch of spack-packages
- Use component versions consistent with specific OM3 releases


---
:rocket: The latest prerelease `access-om3/pr150-13` at 4f86438d4a882b0774532415d71bc1b58fe6a9d0 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/150#issuecomment-3332012076 :rocket:
















