### PR TITLE
Can pre-release infra be used to build MOM6 standalone

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -29,6 +29,7 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '~access3'
     access-ww3:
       require:
         - '@2025.08.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,8 +5,8 @@
 # Instructions for editing this file are found in 
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
-  specs:
-    - access-om3@git.2025.08.001
+  specs:    
+    - access-mom6@2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3
   packages:
     # Main Dependencies
     access3:
@@ -29,7 +29,6 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - '~access3'
     access-ww3:
       require:
         - '@2025.08.000'


### PR DESCRIPTION
Attempting to run mom6 standalone, Harshula said we can use pre-release infra'!

---
:rocket: The latest prerelease `access-om3/pr151-4` at 279fb07b9836feaf87d312443adea72c36f9e561 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/151#issuecomment-3342432820 :rocket:


