### PR TITLE
Change wave attenuation scheme to IC4

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -31,7 +31,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
-        - '@git.64439ad887e78e150293657d7fd1cf7c97c611e6'
+        - '@git.b6ea80750dd6e337ed9d48458c85514e71ce7f84'
     access3-share:
       require:
         - '@2025.08.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -31,7 +31,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
-        - '@git.b6bd6fb82fd71c39d60c8188cc2d0c9763ad0ee9'
+        - '@git.bb5dfccf1d64d10f17db9760c0c83073e07fa339'
     access3-share:
       require:
         - '@2025.08.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -31,7 +31,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
-        - '@git.b6ea80750dd6e337ed9d48458c85514e71ce7f84'
+        - '@git.b6bd6fb82fd71c39d60c8188cc2d0c9763ad0ee9'
     access3-share:
       require:
         - '@2025.08.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -31,7 +31,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
-        - '@git.b1833dd6ecef27f6692c57d226163da591819c70'
+        - '@git.64439ad887e78e150293657d7fd1cf7c97c611e6'
     access3-share:
       require:
         - '@2025.08.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -31,7 +31,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
-        - '@2025.08.000'
+        - '@git.3b99c3c8832e73bca8e3c21099a9044854b21e5a'
     access3-share:
       require:
         - '@2025.08.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -31,7 +31,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
-        - '@git.3b99c3c8832e73bca8e3c21099a9044854b21e5a'
+        - '@git.b1833dd6ecef27f6692c57d226163da591819c70'
     access3-share:
       require:
         - '@2025.08.000'


### PR DESCRIPTION
This is a draft PR to test IC4 wave attenuation scheme and updated numerics in WW3


---
:rocket: The latest prerelease `access-om3/pr152-5` at e0cdb566331054365320b831beba33d15f6e5d58 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/152#issuecomment-3388041898 :rocket:




