### PR TITLE
Testing of ANU-tub using different MOM versions: Jbisits (Issue: #155)

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -35,6 +35,9 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+
+            package_attributes:
+              git: https://github.com/jbisits/MOM6.git
     access-ww3:
       require:
         - '@2025.08.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
     # see https://github.com/ACCESS-NRI/spack-packages/blob/fd44ae03141eab221ce0e5b587dbb9c81d411fcb/packages/access-mom6/package.py#L27
     # link regarding the Debug flag https://spack-tutorial.readthedocs.io/en/latest/tutorial_buildsystems.html#cmake
     - access-mom6@git.6e705048aa6b400ee7630ef8e2be94d415fff86f=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3
-    - access-mom6@git.6e705048aa6b400ee7630ef8e2be94d415fff86f=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3 build_type=Debug
+    # - access-mom6@git.6e705048aa6b400ee7630ef8e2be94d415fff86f=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3 build_type=Debug
   packages:
     # Main Dependencies
     access3:

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,8 +11,8 @@ spack:
     # =2025.07.000 means spack will use that set of dependencies to concretise
     # see https://github.com/ACCESS-NRI/spack-packages/blob/fd44ae03141eab221ce0e5b587dbb9c81d411fcb/packages/access-mom6/package.py#L27
     # link regarding the Debug flag https://spack-tutorial.readthedocs.io/en/latest/tutorial_buildsystems.html#cmake
-    - access-mom6@git.3612119ce778e54d0d2fe35011bf42005afd7d0c=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3
-    - access-mom6@git.3612119ce778e54d0d2fe35011bf42005afd7d0c=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3 build_type=Debug
+    - access-mom6@git.d68ff1250e3fc8c75bf3bafc60b935fe5f7417a1=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3
+    - access-mom6@git.d68ff1250e3fc8c75bf3bafc60b935fe5f7417a1=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3 build_type=Debug
   packages:
     # Main Dependencies
     access3:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,12 +7,12 @@
 spack:
   specs:
     # used to have: - access-om3@git.2025.08.001
-    # Jbisits MOM6 code https://github.com/jbisits/MOM6/commit/3612119ce778e54d0d2fe35011bf42005afd7d0c
+    # Jbisits MOM6 code https://github.com/jbisits/MOM6/commit/6e705048aa6b400ee7630ef8e2be94d415fff86f
     # =2025.07.000 means spack will use that set of dependencies to concretise
     # see https://github.com/ACCESS-NRI/spack-packages/blob/fd44ae03141eab221ce0e5b587dbb9c81d411fcb/packages/access-mom6/package.py#L27
     # link regarding the Debug flag https://spack-tutorial.readthedocs.io/en/latest/tutorial_buildsystems.html#cmake
-    - access-mom6@git.d68ff1250e3fc8c75bf3bafc60b935fe5f7417a1=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3
-    - access-mom6@git.d68ff1250e3fc8c75bf3bafc60b935fe5f7417a1=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3 build_type=Debug
+    - access-mom6@git.6e705048aa6b400ee7630ef8e2be94d415fff86f=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3
+    - access-mom6@git.6e705048aa6b400ee7630ef8e2be94d415fff86f=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3 build_type=Debug
   packages:
     # Main Dependencies
     access3:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,13 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.08.001
+    # used to have: - access-om3@git.2025.08.001
+    # Jbisits MOM6 code https://github.com/jbisits/MOM6/commit/3612119ce778e54d0d2fe35011bf42005afd7d0c
+    # =2025.07.000 means spack will use that set of dependencies to concretise
+    # see https://github.com/ACCESS-NRI/spack-packages/blob/fd44ae03141eab221ce0e5b587dbb9c81d411fcb/packages/access-mom6/package.py#L27
+    # link regarding the Debug flag https://spack-tutorial.readthedocs.io/en/latest/tutorial_buildsystems.html#cmake
+    - access-mom6@git.3612119ce778e54d0d2fe35011bf42005afd7d0c=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3
+    - access-mom6@git.3612119ce778e54d0d2fe35011bf42005afd7d0c=2025.07.000 fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll" ~access3 build_type=Debug
   packages:
     # Main Dependencies
     access3:

--- a/spack.yaml
+++ b/spack.yaml
@@ -2,7 +2,7 @@
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.
-# Instructions for editing this file are found in 
+# Instructions for editing this file are found in
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
@@ -35,9 +35,8 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-
-            package_attributes:
-              git: https://github.com/jbisits/MOM6.git
+      package_attributes:
+        git: https://github.com/jbisits/MOM6.git
     access-ww3:
       require:
         - '@2025.08.000'


### PR DESCRIPTION
Related: #155 

This is for testing.

Note, re: [9385396](https://github.com/ACCESS-NRI/ACCESS-OM3/pull/156/commits/938539612332491a9ef9159990fc93c2a603efe5):
```yaml
    # used to have: - access-om3@git.2025.08.001
    # Jbisits MOM6 code https://github.com/jbisits/MOM6/commit/3612119ce778e54d0d2fe35011bf42005afd7d0c
    # =2025.07.000 means spack will use that set of dependencies to concretise
    # see https://github.com/ACCESS-NRI/spack-packages/blob/fd44ae03141eab221ce0e5b587dbb9c81d411fcb/packages/access-mom6/package.py#L27
    # link regarding the Debug flag https://spack-tutorial.readthedocs.io/en/latest/tutorial_buildsystems.html#cmake
```

See [here for some more details](https://access-community-hub.github.io/access-iom3-configs/infrastructure/Building/) on how this works.

DO NOT MERGE

---
:rocket: The latest prerelease `access-om3/pr156-6` at a9e7e80a01eda35d6cea9b118aac53539462fd65 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/156#issuecomment-3530340606 :rocket:






