### PR TITLE
Infra Update `v8`: `spack v1` Support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
+    uses: access-nri/build-cd/.github/workflows/cd.yml@test-v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,7 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
-      spack-manifest-schema-version: 1-0-7
+      spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       contents: write

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,7 +8,7 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@test-v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0
@@ -22,7 +22,7 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@test-v8
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -32,7 +32,7 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@test-v8
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,7 +8,7 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0
@@ -22,7 +22,7 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -32,7 +32,7 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -11,7 +11,6 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      pr: ${{ github.event.issue.number }}
       spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,12 +8,12 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       pr: ${{ github.event.issue.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -23,7 +23,7 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -33,7 +33,7 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     # This job is responsible for checks and prerelease deployments
     # that happen when a PR is modified or opened
     if: github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@test-v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0
@@ -37,5 +37,5 @@ jobs:
     # This job is responsible for cleaning up the Prereleases after a
     # PR is closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@test-v8
     secrets: inherit # inherit GitHub Deployment environment secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      pr: ${{ github.event.pull_request.number }}
       spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
@@ -39,6 +38,4 @@ jobs:
     # PR is closed
     if: github.event.action == 'closed'
     uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
-    with:
-      root-sbd: ${{ vars.NAME }}
     secrets: inherit # inherit GitHub Deployment environment secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     with:
       model: ${{ vars.NAME }}
       pr: ${{ github.event.pull_request.number }}
-      spack-manifest-schema-version: 1-0-7
+      spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     # This job is responsible for checks and prerelease deployments
     # that happen when a PR is modified or opened
     if: github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0
@@ -37,5 +37,5 @@ jobs:
     # This job is responsible for cleaning up the Prereleases after a
     # PR is closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@test-v8
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     secrets: inherit # inherit GitHub Deployment environment secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,13 @@ jobs:
     name: CI
     # This job is responsible for checks and prerelease deployments
     # that happen when a PR is modified or opened
-    if: >-
-      github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    if: github.event.action != 'closed'
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       pr: ${{ github.event.pull_request.number }}
       spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -39,7 +38,7 @@ jobs:
     # This job is responsible for cleaning up the Prereleases after a
     # PR is closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     with:
       root-sbd: ${{ vars.NAME }}
     secrets: inherit # inherit GitHub Deployment environment secrets

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2025.08.003"
+  "access-spack-packages": "2026.02.002"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
-    "spack": "0.22",
-    "spack-packages": "2025.08.003"
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
+  "spack": "1.0",
+  "access-spack-packages": "2025.08.003"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
-  "spack": "1.0",
+  "spack": "1.1",
   "access-spack-packages": "2025.08.003"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,7 +8,7 @@ spack:
   # _name and _version are reserved definitions that inform deployments
   definitions:
   - _name: [access-om3]
-  - _version: [2025.08.001]
+  - _version: [2025.08.002]
   specs:
   - access-om3
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -63,10 +63,10 @@ spack:
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     parallelio:
       require:
-      - '@2.6.2'
+      - '@2.6.8'
     netcdf-c:
       require:
-      - '@4.9.2'
+      - '@4.9.3'
       - build_system=cmake build_type=RelWithDebInfo
     netcdf-fortran:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,8 +5,12 @@
 # Instructions for editing this file are found in 
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
+  # _name and _version are reserved definitions that inform deployments
+  definitions:
+  - _name: [access-om3]
+  - _version: [2025.08.001]
   specs:
-  - access-om3@git.2025.08.001
+  - access-om3
   packages:
     # Main Dependencies
     access3:
@@ -79,10 +83,15 @@ spack:
       - '@4.1.2'
     gcc-runtime:
       require:
-      - '%gcc'
+      - '%access_gcc'
+
+    # Compilers
+    intel-oneapi-compilers:
+      require:
+      - '@2025.2.0'
     all:
       require:
-      - '%oneapi@2025.2.0'
+      - '%access_oneapi'
       - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,84 +6,84 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.08.001
+  - access-om3@git.2025.08.001
   packages:
     # Main Dependencies
     access3:
       require:
-        - '@2025.08.000'
-        - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - '@2025.08.000'
+      - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-        - '@CICE6.6.1-0'
-        - io_type=PIO
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - '@CICE6.6.1-0'
+      - io_type=PIO
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@2025.07.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - '@2025.07.000'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
-        - '@2025.08.000'
+      - '@2025.08.000'
     access3-share:
       require:
-        - '@2025.08.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - '@2025.08.000'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-        - '@2025.08.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - '@2025.08.000'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mocsy:
       require:
-        - '@2025.07.002'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - '@2025.07.002'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     # Other Dependencies
     esmf:
       require:
-        - '@8.7.0'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - '@8.7.0'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     parallelio:
       require:
-        - '@2.6.2'
+      - '@2.6.2'
     netcdf-c:
       require:
-        - '@4.9.2'
-        - build_system=cmake build_type=RelWithDebInfo
+      - '@4.9.2'
+      - build_system=cmake build_type=RelWithDebInfo
     netcdf-fortran:
       require:
-        - '@4.6.1'
+      - '@4.6.1'
     fms:
       require:
-        - '@2025.03'
-        - 'cppflags="-DMAXFIELDMETHODS_=600"'
+      - '@2025.03'
+      - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:
-        - '@4.1.7'
+      - '@4.1.7'
     fortranxml:
       require:
-        - '@4.1.2'
+      - '@4.1.2'
     gcc-runtime:
       require:
-        - '%gcc'
+      - '%gcc'
     all:
       require:
-        - '%oneapi@2025.2.0'
-        - 'target=x86_64_v4'
+      - '%oneapi@2025.2.0'
+      - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -2,7 +2,7 @@
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.
-# Instructions for editing this file are found in 
+# Instructions for editing this file are found in
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   # _name and _version are reserved definitions that inform deployments
@@ -81,17 +81,20 @@ spack:
     fortranxml:
       require:
       - '@4.1.2'
-    gcc-runtime:
-      require:
-      - '%access_gcc'
 
     # Compilers
-    intel-oneapi-compilers:
+    c:
       require:
-      - '@2025.2.0'
+      - 'intel-oneapi-compilers@2025.2.0'
+    cxx:
+      require:
+      - 'intel-oneapi-compilers@2025.2.0'
+    fortran:
+      require:
+      - 'intel-oneapi-compilers@2025.2.0'
+
     all:
-      require:
-      - '%access_oneapi'
+      prefer:
       - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -95,7 +95,7 @@ spack:
 
     all:
       prefer:
-      - 'target=x86_64_v4'
+      - 'target=x86_64'
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
References issue ACCESS-NRI/build-cd#313 and PR ACCESS-NRI/build-cd#326
References rollout issue ACCESS-NRI/build-cd#328
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!NOTE]
> This infrastructure update created a new Release, but it maintained reproducibility with the current `main`

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for deployments to `spack < 1.0`.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-cd < v8`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-cd >= v8`.

## Background

We are moving on up to `spack v1`! This update to spack contains many bug fixes, optimisations and new features that can be incorporated into `build-cd`.

This update also contains changes that make `spack v0.X` incompatible with this `build-cd v8` update - the most prominent one being the splitting of spacks core codebase from it's builtin spack-packages repo. This means that for provenance, one to keep track of both `builtin` spack-packages and our own, renamed `access-spack-packages`. `build-cd` will centrally control the version of builtin `spack-packages` for a given instance, and `config/versions.json`s `spack-packages` key is renamed to `access-spack-packages`.

As noted earlier, this major version of `build-cd` can only support `spack v1`, due to `spack v1`-specific commands in the infrastructure. If you still want to deploy to `spack v0.X`, you will need to change `build-cd` to `v7`, and update the `config/versions.json` file/`spack.yaml`.

## Features

* **Support for spack v1**: We're moving to a new, non-beta version of spack! It contains bug fixes, features and optimisations over the old version.

## Prerequisites for Merging

- [x] Update `build-cd` entrypoints (this PR!)
- [x] Update `config/versions.json` with new inputs (also this PR!)
- [x] Validate compiler additions to the spack manifest (this PR, too!)
- [x] Test and Verify Model built with `spack v1`


---
:rocket: The latest prerelease `access-om3/pr163-6` at 7af308f6cd71bc4cf53b89cd01ce9cd5ba21fd2e is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/163#issuecomment-3956641335 :rocket:






