### PR TITLE
MOM6 PR test: gfdl-to-main-2025-09-25

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@2025.07.000'
+        - '@git.0320cf9e9fbf420aa0edf4170eb0ac93509a23d0=2025.07.000'  # On PR-test/gfdl-to-main-2025-09-25
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
PR for building prereleases to test/review https://github.com/mom-ocean/MOM6/pull/1680

---
:rocket: The latest prerelease `access-om3/pr164-1` at 39d83ad504502dd2897c7b1fbc31c0c91859583d is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/164#issuecomment-3585283246 :rocket:
