### PR TITLE
Deploy MOM6 solo exe with ACCESS-OM3

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.08.003"
+    "spack-packages": "ecc03d83173325cd8255ffe9eaba3ff8904422da"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,7 +7,6 @@
 spack:
   specs:
     - access-om3@git.2025.08.001
-    - access-mom6 ~access3
   packages:
     # Main Dependencies
     access3:
@@ -26,7 +25,8 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-        - '@2025.07.000'
+        - '@git.078fc7d944c0d2b2b4e4ddf1ce7cacc617f20d0f' #  On cmake-allow-exe
+        - +mom6_solo
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
@@ -85,11 +85,6 @@ spack:
       require:
         - '%oneapi@2025.2.0'
         - 'target=x86_64_v4'
-  view: false
-  modules:
-      default:
-          tcl:
-              projections:
-                  access-mom6: '{name}/{version}-{variants.access3.value}'
+  view: true
   concretizer:
-    unify: when_possible
+    unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,7 @@
 spack:
   specs:
     - access-om3@git.2025.08.001
+    - access-mom6 ~access3
   packages:
     # Main Dependencies
     access3:
@@ -86,4 +87,4 @@ spack:
         - 'target=x86_64_v4'
   view: true
   concretizer:
-    unify: true
+    unify: when_possible

--- a/spack.yaml
+++ b/spack.yaml
@@ -85,6 +85,11 @@ spack:
       require:
         - '%oneapi@2025.2.0'
         - 'target=x86_64_v4'
-  view: true
+  view: false
+  modules:
+      default:
+          tcl:
+              projections:
+                  access-mom6: '{name}/{version}-{variants.access3.value}'
   concretizer:
     unify: when_possible


### PR DESCRIPTION
This PR adds a spec to build MOM6 ocean-only

---
:rocket: The latest prerelease `access-om3/pr166-3` at a8bb9b3482cd680b986bf56ea0fc1f45a8354fa0 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/166#issuecomment-3606531494 :rocket:


