### PR TITLE
Testing: CDEP'S CMakeLists.txt: redundant calls to "internal" fox code in CDEPS/CMakeLists.txt

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@2025.08.000'
+        - '@33fc4f88977858a49533cc50a7da92a6e189e971'
         - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
@@ -34,7 +34,7 @@ spack:
         - '@2025.08.000'
     access3-share:
       require:
-        - '@2025.08.000'
+        - '@33fc4f88977858a49533cc50a7da92a6e189e971'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
Testing: https://github.com/ACCESS-NRI/access3-share/pull/21

---
:rocket: The latest prerelease `access-om3/pr180-1` at 9bb479270cc80b389d9ac493eabd4ad3cd848703 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/180#issuecomment-3752821750 :rocket:

