### PR TITLE
Test access-generic-tracers update: chl and light attenuation updates

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -40,7 +40,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-        - '@2025.08.000'
+        - '@git.9822bb3aeb2dec6c0e4699bd56ae4617b54d7ace=2025.08.000'  # On branch WOMBATupdate-2026-01-19
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.08.001
+    - access-om3@git.2025.08.001 ^/hkm4lrd
   packages:
     # Main Dependencies
     access3:
@@ -40,7 +40,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-        - '@git.9822bb3aeb2dec6c0e4699bd56ae4617b54d7ace=2025.08.000'  # On branch WOMBATupdate-2026-01-19
+        - '@git.a551ae636feca9f7269f36846468ccc907b84319=2025.08.000'  # On branch WOMBATupdate-2026-01-19
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -40,7 +40,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-        - '@git.a551ae636feca9f7269f36846468ccc907b84319=2025.08.000'  # On branch WOMBATupdate-2026-01-19
+        - '@git.2124c7eb002c819b761e2cb8b5a027db68c13ae6=2025.08.000'  # On branch fortitude
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
This PR is to generate a prerelease for testing https://github.com/ACCESS-NRI/GFDL-generic-tracers/pull/84

---
:rocket: The latest prerelease `access-om3/pr182-3` at 6b37503898ed423e7f9e52e4c8ef9aa0b3410689 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/182#issuecomment-3814837753 :rocket:


