### PR TITLE
Prerelease using latest `NOAA-GFDL/MOM6` with Claire's ice-shelf changes

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -87,6 +87,8 @@ spack:
       require:
         - '%oneapi@2025.2.0'
         - 'target=x86_64_v4'
+  config:
+    build_jobs: 1
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-      - '@2026.03.000'
+      - '@git.d63adae27696f2caae36625a80dcd436e03475cd=2026.03.000'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
@@ -38,7 +38,7 @@ spack:
       - '@2026.03.000'
     access3-share:
       require:
-      - '@2026.03.000'
+      - '@git.d63adae27696f2caae36625a80dcd436e03475cd=2026.03.000'
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
       - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.08.001
+    - access-om3@git.2025.08.001 ^/3nq5qch
   packages:
     # Main Dependencies
     access3:
@@ -20,9 +20,9 @@ spack:
       require:
         - '@CICE6.6.1-0'
         - io_type=PIO
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-mom6:
       require:
         - '@git.9b5014887a95cfbe9462079d8f938a4d5d73ab11=2026.01.000'  # On branch dev/gfdl+access+isf

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.08.001
+    - access-om3@git.2025.08.001 ^/bmqjm4u
   packages:
     # Main Dependencies
     access3:
@@ -25,7 +25,7 @@ spack:
         - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-mom6:
       require:
-        - '@git.fc24c40d7f2050ee4febbf8885a4cb1f185d9ccf=2026.01.000'  # On branch dev/gfdl+access+isf
+        - '@git.9b5014887a95cfbe9462079d8f938a4d5d73ab11=2026.01.000'  # On branch dev/gfdl+access+isf
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
         - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,9 +13,9 @@ spack:
       require:
         - '@2025.08.000'
         - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-cice:
       require:
         - '@CICE6.6.1-0'
@@ -26,44 +26,43 @@ spack:
     access-mom6:
       require:
         - '@git.9b5014887a95cfbe9462079d8f938a4d5d73ab11=2026.01.000'  # On branch dev/gfdl+access+isf
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-ww3:
       require:
         - '@2025.08.000'
     access3-share:
       require:
         - '@2025.08.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-generic-tracers:
       require:
         - '@2025.08.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-mocsy:
       require:
         - '@2025.07.002'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     fms:
       require:
         - '@2025.03'
         - 'cppflags="-DMAXFIELDMETHODS_=600"'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     # Other Dependencies
     esmf:
       require:
         - '@8.8.1'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,7 +29,7 @@ spack:
       - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-mom6:
       require:
-      - '@git.87cd5978c25ae2ebd761119d3dffd6665d729f08=2026.01.001'  # On branch dev/gfdl+access+isf
+      - '@git.5100ba4e1c1baff83d1b74b59b56e397f7398f38=2026.01.001'  # On branch dev/gfdl+access+isf
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
       - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,50 +13,57 @@ spack:
       require:
         - '@2025.08.000'
         - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-cice:
       require:
         - '@CICE6.6.1-0'
         - io_type=PIO
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-mom6:
       require:
-        - '@2025.07.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@git.fc24c40d7f2050ee4febbf8885a4cb1f185d9ccf=2026.01.000'  # On branch dev/gfdl+access+isf
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-ww3:
       require:
         - '@2025.08.000'
     access3-share:
       require:
         - '@2025.08.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-generic-tracers:
       require:
         - '@2025.08.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-mocsy:
       require:
         - '@2025.07.002'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+    fms:
+      require:
+        - '@2025.03'
+        - 'cppflags="-DMAXFIELDMETHODS_=600"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     # Other Dependencies
     esmf:
       require:
-        - '@8.7.0'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@8.8.1'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     parallelio:
       require:
         - '@2.6.2'
@@ -67,10 +74,6 @@ spack:
     netcdf-fortran:
       require:
         - '@4.6.1'
-    fms:
-      require:
-        - '@2025.03'
-        - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:
         - '@4.1.7'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,16 +6,16 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.08.001 ^/bmqjm4u
+    - access-om3@git.2025.08.001
   packages:
     # Main Dependencies
     access3:
       require:
         - '@2025.08.000'
         - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
     access-cice:
       require:
         - '@CICE6.6.1-0'
@@ -26,44 +26,44 @@ spack:
     access-mom6:
       require:
         - '@git.9b5014887a95cfbe9462079d8f938a4d5d73ab11=2026.01.000'  # On branch dev/gfdl+access+isf
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
     access-ww3:
       require:
         - '@2025.08.000'
     access3-share:
       require:
         - '@2025.08.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
     access-generic-tracers:
       require:
         - '@2025.08.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
     access-mocsy:
       require:
         - '@2025.07.002'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
     fms:
       require:
         - '@2025.03'
         - 'cppflags="-DMAXFIELDMETHODS_=600"'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
     # Other Dependencies
     esmf:
       require:
         - '@8.8.1'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin"'
+        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto=thin -fuse-ld=lld"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
   specs:
-    - access-om3@git.2025.08.001 ^/3nq5qch
+    - access-om3@git.2025.08.001
   packages:
     # Main Dependencies
     access3:
@@ -20,9 +20,8 @@ spack:
       require:
         - '@CICE6.6.1-0'
         - io_type=PIO
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
-        - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
     access-mom6:
       require:
         - '@git.9b5014887a95cfbe9462079d8f938a4d5d73ab11=2026.01.000'  # On branch dev/gfdl+access+isf
@@ -59,7 +58,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-        - '@8.8.1'
+        - '@8.7.0'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,7 +29,7 @@ spack:
       - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-mom6:
       require:
-      - '@git.d8f109ede36ad6d0dc86c9948d2f93878a67b321=2026.05.001'  # On branch dev/gfdl+access+isf
+      - '@git.93aea27f73125e437623f466507ab634c2a2506e=2026.05.001'  # On branch dev/gfdl@3d479de+access+isf
       - +mom6_solo
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,7 +29,7 @@ spack:
       - 'ldflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto -fuse-ld=lld"'
     access-mom6:
       require:
-      - '@git.2610fdea91252e6742efe79e48dbf78d352df141=2026.05.001'  # On branch dev/gfdl+access+isf
+      - '@git.d8f109ede36ad6d0dc86c9948d2f93878a67b321=2026.05.001'  # On branch dev/gfdl+access+isf
       - +mom6_solo
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -O3 -flto"'


### PR DESCRIPTION
This PR is to deploy a prerelease using the  [`dev/gfdl+access+isf`](https://github.com/ACCESS-NRI/MOM6/tree/dev/gfdl%2Baccess%2Bisf) branch of MOM6. This branch is:
- based on the [NOAA-GFDL/MOM6:dev/gfdl](https://github.com/NOAA-GFDL/MOM6/tree/dev/gfdl) branch:
  - `pr189-6`: [`NOAA-GFDL/MOM6@ae752b6`](https://github.com/NOAA-GFDL/MOM6/tree/ae752b6)
  - `pr189-11`-`pr189-13`: [`NOAA-GFDL/MOM6@3d479de`](https://github.com/NOAA-GFDL/MOM6/tree/3d479de)
  - `pr189-18`: [`NOAA-GFDL/MOM6@759c03a`](https://github.com/NOAA-GFDL/MOM6/tree/759c03a)
  - `pr189-19`: back to [`NOAA-GFDL/MOM6@3d479de`](https://github.com/NOAA-GFDL/MOM6/tree/3d479de)
- includes ACCESS changes from the [2026.05](https://github.com/ACCESS-NRI/MOM6/tree/2026.05) branch
- includes @claireyung's [ice shelf changes](https://github.com/ACCESS-NRI/MOM6/pull/38).

Compiler flag changes from https://github.com/ACCESS-NRI/ACCESS-OM3/pull/142 are also included.

This prerelease could possibly replace https://github.com/ACCESS-NRI/ACCESS-OM3/pull/142, pending approval from @claireyung.

---
:rocket: The latest prerelease `access-om3/pr189-18` at e51357780eb276ad31bedf0ff5291099049c4eb0 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/189#issuecomment-4704132062 :rocket:





---
:rocket: The latest prerelease `access-om3/pr189-19` at 1e97b1e14d0fc877efb0a34a7801ebae55056adb is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/189#issuecomment-4766508825 :rocket:
