### PR TITLE
Update to WOMBATlite 2026.02.000

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.002"
+  "access-spack-packages": "2026.03.001"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,7 +44,7 @@ spack:
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-      - '@2025.08.000'
+      - '@2026.02.000'
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
@@ -95,7 +95,7 @@ spack:
 
     all:
       prefer:
-      - 'target=x86_64'
+      - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
Updates to WOMBATlite 2026.02.000 for testing. Also sets target=x86_64_v4` which will change answers (see https://github.com/ACCESS-NRI/ACCESS-OM3/issues/200)

---
:rocket: The latest prerelease `access-om3/pr206-2` at da5914551fc7981016a4d6a926093bd93190fa71 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/206#issuecomment-4027388860 :rocket:

