### PR TITLE
Regional update coupled names

### DIFF
--- a/config/packages.json
+++ b/config/packages.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/packages/1-0-0.json",
   "provenance": [
+    "access-cice",
     "access-mom6",
     "access3",
     "access3-share",

--- a/config/packages.json
+++ b/config/packages.json
@@ -3,7 +3,6 @@
   "provenance": [
     "access-cice",
     "access-mom6",
-    "access-ww3",
     "access3",
     "access3-share",
     "access-generic-tracers",

--- a/config/packages.json
+++ b/config/packages.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/packages/1-0-0.json",
   "provenance": [
-    "access-cice",
     "access-mom6",
     "access3",
     "access3-share",

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "01602e9d215520e88cf3b8f64162bd0406dbcddb"
+    "spack-packages": "2025.08.003"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "http://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.08.003"
+    "spack-packages": "01602e9d215520e88cf3b8f64162bd0406dbcddb"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access-cice:
       require:
-        - '@git.8e1472b69a574042dad773ff38d9be7c5010e4b2'
+        - '@git.f78e6ce774cc6767961db4de79a710383af1e515'
         - io_type=PIO
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.c99e25f05d41f266989e96a811684e6685bc1cff'
+        - '@git.1ea761374581fed22f01c973af36e9f3d5f57ec6'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -32,7 +32,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.c99e25f05d41f266989e96a811684e6685bc1cff'
+        - '@git.1ea761374581fed22f01c973af36e9f3d5f57ec6'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,14 +12,14 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.387eaa88a88fac8dbc2cdee5309dcb8c04fa4835'
+        - '@git.370ddef24355deeb693ca0e256836e7bed322628'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access-cice:
       require:
-        - '@git.a6bb0046fa4f63e07cd6222dd401e0537a158207'
+        - '@git.8e1472b69a574042dad773ff38d9be7c5010e4b2'
         - io_type=PIO
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -32,7 +32,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.387eaa88a88fac8dbc2cdee5309dcb8c04fa4835'
+        - '@git.370ddef24355deeb693ca0e256836e7bed322628'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -19,7 +19,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access-cice:
       require:
-        - '@git.475363c7a246af5cf8b79ebb6d977c4594bb9034'
+        - '@git.ccf9fef7003ea44e30a76164d06dbce729b88b9f'
         - io_type=PIO
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -14,47 +14,47 @@ spack:
       require:
         - '@git.c4e758b48dad21c9b2c55a196714406c0ff6528f'
         - configurations=MOM6-CICE6
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access-cice:
       require:
         - '@git.a6bb0046fa4f63e07cd6222dd401e0537a158207'
         - io_type=PIO
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access-mom6:
       require:
         - '@2025.07.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
         - '@git.c4e758b48dad21c9b2c55a196714406c0ff6528f'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access-generic-tracers:
       require:
         - '@2025.08.000'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access-mocsy:
       require:
         - '@2025.07.002'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     # Other Dependencies
     esmf:
       require:
         - '@8.7.0'
-        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -20,6 +20,7 @@ spack:
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - build_type=Debug
     # access-cice:
     #   require:
     #     - '@git.ccf9fef7003ea44e30a76164d06dbce729b88b9f'

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,6 +5,9 @@
 # Instructions for editing this file are found in 
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
+  definitions:
+    - _name: [ access-om3 ]
+    - _version: [ 2025.08.002 ]
   specs:
     - access-om3@git.2025.08.001
     - gcom@8.0

--- a/spack.yaml
+++ b/spack.yaml
@@ -81,10 +81,18 @@ spack:
     gcc-runtime:
       require:
         - '%gcc'
-    all:
+    c:
       require:
-        - '%intel@2021.10.0'
-        - 'target=x86_64_v4'
+        - 'intel-oneapi-compilers-classic@2021.10.0'
+    cxx:
+      require:
+        - 'intel-oneapi-compilers-classic@2021.10.0'
+    fortran:
+      require:
+         - 'intel-oneapi-compilers-classic@2021.10.0'
+    all:
+      prefer:
+        - 'target=x86_64'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,17 +16,17 @@ spack:
     access3:
       require:
         - '@git.33c3e2791df4e048aff49359b61718084dc14cdf'
-        - configurations=MOM6
+        - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
-    # access-cice:
-    #   require:
-    #     - '@git.ccf9fef7003ea44e30a76164d06dbce729b88b9f'
-    #     - io_type=PIO
-    #     - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
-    #     - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
-    #     - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+    access-cice:
+      require:
+        - '@git.ccf9fef7003ea44e30a76164d06dbce729b88b9f'
+        - io_type=PIO
+        - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access-mom6:
       require:
         - '@2025.07.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,15 +11,14 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@f73d8775d6c9358a8c0d57a3ec5e7ddd204e0db6'
+        - '@git.c4e758b48dad21c9b2c55a196714406c0ff6528f'
         - configurations=MOM6-CICE6
-        - '+cm3'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-        - '@ee85cdebac820226180b20b0376fab6bfcb9d72a'
+        - '@git.a6bb0046fa4f63e07cd6222dd401e0537a158207'
         - io_type=PIO
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
@@ -32,7 +31,7 @@ spack:
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access3-share:
       require:
-        - '@2025.08.000'
+        - '@git.c4e758b48dad21c9b2c55a196714406c0ff6528f'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,7 @@
 spack:
   definitions:
     - _name: [ access-om3 ]
+    - _version: [ 2025.08.999 ]
   specs:
     - access-om3
     - gcom@8.0

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.f029178c901189aaeb0cfac5667b6dae0ba93592'
+        - '@git.c99e25f05d41f266989e96a811684e6685bc1cff'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -32,7 +32,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.f029178c901189aaeb0cfac5667b6dae0ba93592'
+        - '@git.c99e25f05d41f266989e96a811684e6685bc1cff'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.c4e758b48dad21c9b2c55a196714406c0ff6528f'
+        - '@git.387eaa88a88fac8dbc2cdee5309dcb8c04fa4835'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -32,7 +32,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.c4e758b48dad21c9b2c55a196714406c0ff6528f'
+        - '@git.387eaa88a88fac8dbc2cdee5309dcb8c04fa4835'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,7 @@
 spack:
   specs:
     - access-om3@git.2025.08.001
+    - gcom@8.0
   packages:
     # Main Dependencies
     access3:
@@ -54,9 +55,6 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-    gcom:
-      require:
-        - '@8.0'
     parallelio:
       require:
         - '@2.6.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.1ea761374581fed22f01c973af36e9f3d5f57ec6'
+        - '@git.370ddef24355deeb693ca0e256836e7bed322628'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -35,7 +35,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.1ea761374581fed22f01c973af36e9f3d5f57ec6'
+        - '@git.370ddef24355deeb693ca0e256836e7bed322628'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,14 +12,14 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.d6876c6eef66f66de04d71f0cfd3d7e61dbf5af3'
+        - '@git.f029178c901189aaeb0cfac5667b6dae0ba93592'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access-cice:
       require:
-        - '@git.f78e6ce774cc6767961db4de79a710383af1e515'
+        - '@git.475363c7a246af5cf8b79ebb6d977c4594bb9034'
         - io_type=PIO
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -32,7 +32,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.d6876c6eef66f66de04d71f0cfd3d7e61dbf5af3'
+        - '@git.f029178c901189aaeb0cfac5667b6dae0ba93592'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.370ddef24355deeb693ca0e256836e7bed322628'
+        - '@git.6cfc07bfa474339fdb6c0d1d53896e275431a216'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -35,7 +35,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.370ddef24355deeb693ca0e256836e7bed322628'
+        - '@git.6cfc07bfa474339fdb6c0d1d53896e275431a216'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -35,7 +35,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.d5f3f8adc26d0b120f6004c7b9d1c255a98492cf'
+        - '@git.370a2282be382faf68f3b6e96d77aa788b11c676'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.5588ddbdb3f8548e6bcf9c7277eaa192c1e82db4'
+        - '@git.33c3e2791df4e048aff49359b61718084dc14cdf'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -35,7 +35,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.5588ddbdb3f8548e6bcf9c7277eaa192c1e82db4'
+        - '@git.33c3e2791df4e048aff49359b61718084dc14cdf'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -33,12 +33,14 @@ spack:
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - build_type=Debug
     access3-share:
       require:
         - '@git.370a2282be382faf68f3b6e96d77aa788b11c676'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+        - build_type=Debug
     access-generic-tracers:
       require:
         - '@2025.08.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.318cb70ff408ee028c15965d28001cd8781033b9'
+        - '@git.d6876c6eef66f66de04d71f0cfd3d7e61dbf5af3'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -32,7 +32,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.318cb70ff408ee028c15965d28001cd8781033b9'
+        - '@git.d6876c6eef66f66de04d71f0cfd3d7e61dbf5af3'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -9,7 +9,7 @@ spack:
     - _name: [ access-om3 ]
     - _version: [ 2025.08.002 ]
   specs:
-    - access-om3@git.2025.08.001
+    - access-om3
     - gcom@8.0
   packages:
     # Main Dependencies

--- a/spack.yaml
+++ b/spack.yaml
@@ -2,100 +2,131 @@
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.
-# Instructions for editing this file are found in
+# Instructions for editing this file are found in 
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack:
-  # _name and _version are reserved definitions that inform deployments
-  definitions:
-  - _name: [access-om3]
-  - _version: [2025.08.002]
   specs:
-  - access-om3
+    - access-om3@git.2025.08.001
   packages:
     # Main Dependencies
     access3:
       require:
-      - '@2025.08.000'
-      - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@f73d8775d6c9358a8c0d57a3ec5e7ddd204e0db6'
+        - configurations=MOM6-CICE6
+        - '+cm3'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-      - '@CICE6.6.1-0'
-      - io_type=PIO
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@ee85cdebac820226180b20b0376fab6bfcb9d72a'
+        - io_type=PIO
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-      - '@2025.07.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-    access-ww3:
-      require:
-      - '@2025.08.000'
+        - '@2025.07.000'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access3-share:
       require:
-      - '@2025.08.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@2025.08.000'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-      - '@2025.08.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@2025.08.000'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mocsy:
       require:
-      - '@2025.07.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@2025.07.002'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     # Other Dependencies
     esmf:
       require:
-      - '@8.7.0'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - '@8.7.0'
+        - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+        - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+    gcom:
+      require:
+        - '@8.0'
     parallelio:
       require:
-      - '@2.6.8'
+        - '@2.6.2'
     netcdf-c:
       require:
-      - '@4.9.3'
-      - build_system=cmake build_type=RelWithDebInfo
+        - '@4.9.2'
+        - build_system=cmake build_type=RelWithDebInfo
     netcdf-fortran:
       require:
-      - '@4.6.1'
+        - '@4.6.1'
     fms:
       require:
-      - '@2025.03'
-      - 'cppflags="-DMAXFIELDMETHODS_=600"'
+        - '@2025.03'
+        - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:
-      - '@4.1.7'
+        - '@4.1.7'
     fortranxml:
       require:
-      - '@4.1.2'
-
-    # Compilers
-    c:
+        - '@4.1.2'
+    gcc-runtime:
       require:
-      - 'intel-oneapi-compilers@2025.2.0'
-    cxx:
-      require:
-      - 'intel-oneapi-compilers@2025.2.0'
-    fortran:
-      require:
-      - 'intel-oneapi-compilers@2025.2.0'
-
+        - '%gcc'
     all:
-      prefer:
-      - 'target=x86_64'
+      require:
+        - '%oneapi@2025.2.0'
+        - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true
+  modules:
+      prefix_inspections:
+        bin:
+         - PATH
+        lib:
+         - LIBRARY_PATH
+         - LD_LIBRARY_PATH
+        lib64:
+         - LIBRARY_PATH
+         - LD_LIBRARY_PATH
+        include:
+         - FPATH
+
+      default:
+        tcl:
+          include:
+            - access-om3
+            - access-mom6
+            - access-cice
+            - access3-share
+            - access3
+            - esmf
+            - fms
+            - parallelio
+            - fortranxml
+            - gcom
+            - openmpi
+            - netcdf-c
+            - netcdf-fortran
+
+          projections:
+            access-om3: '{name}/2025.x.0'
+            access-cice: '{name}/access-cm3-CICE6.6.1-0-{hash:7}'
+            access-mom6: '{name}/cmake_build-{hash:7}'
+            access3-share: '{name}/access-cm3-2025.12.0-{hash:7}'
+            parallelio: '{name}/2.6.2-{hash:7}'
+            fortranxml: '{name}/4.1.2-{hash:7}'
+            fms: '{name}/2024.03-{hash:7}'
+            esmf: '{name}/v8.7.0-{hash:7}'
+            netcdf-c: '{name}/4.9.2-{hash:7}'
+            netcdf-fortran: '{name}/4.6.1-{hash:7}'
+            gcom: '{name}/8.0-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.3e96f8ea51c5384045ecdab5467107a58778617c'
+        - '@git.5588ddbdb3f8548e6bcf9c7277eaa192c1e82db4'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -35,7 +35,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.3e96f8ea51c5384045ecdab5467107a58778617c'
+        - '@git.5588ddbdb3f8548e6bcf9c7277eaa192c1e82db4'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -80,7 +80,7 @@ spack:
         - '%gcc'
     all:
       require:
-        - '%oneapi@2025.2.0'
+        - '%intel@2021.10.0'
         - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,7 +7,6 @@
 spack:
   definitions:
     - _name: [ access-om3 ]
-    - _version: [ 2025.08.002 ]
   specs:
     - access-om3
     - gcom@8.0

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.370ddef24355deeb693ca0e256836e7bed322628'
+        - '@git.318cb70ff408ee028c15965d28001cd8781033b9'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -32,7 +32,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.370ddef24355deeb693ca0e256836e7bed322628'
+        - '@git.318cb70ff408ee028c15965d28001cd8781033b9'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,14 +11,15 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@2025.08.000'
-        - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
+        - '@f73d8775d6c9358a8c0d57a3ec5e7ddd204e0db6'
+        - configurations=MOM6-CICE6
+        - '+cm3'
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-        - '@CICE6.6.1-0'
+        - '@ee85cdebac820226180b20b0376fab6bfcb9d72a'
         - io_type=PIO
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
@@ -29,9 +30,6 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-    access-ww3:
-      require:
-        - '@2025.08.000'
     access3-share:
       require:
         - '@2025.08.000'
@@ -57,6 +55,9 @@ spack:
         - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
         - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+    gcom:
+      require:
+        - '@8.0'
     parallelio:
       require:
         - '@2.6.2'
@@ -87,3 +88,45 @@ spack:
   view: true
   concretizer:
     unify: true
+  modules:
+      prefix_inspections:
+        bin:
+         - PATH
+        lib:
+         - LIBRARY_PATH
+         - LD_LIBRARY_PATH
+        lib64:
+         - LIBRARY_PATH
+         - LD_LIBRARY_PATH
+        include:
+         - FPATH
+
+      default:
+        tcl:
+          include:
+            - access-om3
+            - access-mom6
+            - access-cice
+            - access3-share
+            - access3
+            - esmf
+            - fms
+            - parallelio
+            - fortranxml
+            - gcom
+            - openmpi
+            - netcdf-c
+            - netcdf-fortran
+
+          projections:
+            access-om3: '{name}/2025.x.0'
+            access-cice: '{name}/access-cm3-CICE6.6.1-0-{hash:7}'
+            access-mom6: '{name}/cmake_build-{hash:7}'
+            access3-share: '{name}/access-cm3-2025.12.0-{hash:7}'
+            parallelio: '{name}/2.6.2-{hash:7}'
+            fortranxml: '{name}/4.1.2-{hash:7}'
+            fms: '{name}/2024.03-{hash:7}'
+            esmf: '{name}/v8.7.0-{hash:7}'
+            netcdf-c: '{name}/4.9.2-{hash:7}'
+            netcdf-fortran: '{name}/4.6.1-{hash:7}'
+            gcom: '{name}/8.0-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,17 +16,17 @@ spack:
     access3:
       require:
         - '@git.33c3e2791df4e048aff49359b61718084dc14cdf'
-        - configurations=MOM6-CICE6
+        - configurations=MOM6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
-    access-cice:
-      require:
-        - '@git.ccf9fef7003ea44e30a76164d06dbce729b88b9f'
-        - io_type=PIO
-        - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
-        - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
-        - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+    # access-cice:
+    #   require:
+    #     - '@git.ccf9fef7003ea44e30a76164d06dbce729b88b9f'
+    #     - io_type=PIO
+    #     - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+    #     - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+    #     - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access-mom6:
       require:
         - '@2025.07.000'
@@ -35,7 +35,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.33c3e2791df4e048aff49359b61718084dc14cdf'
+        - '@git.d5f3f8adc26d0b120f6004c7b9d1c255a98492cf'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
     # Main Dependencies
     access3:
       require:
-        - '@git.6cfc07bfa474339fdb6c0d1d53896e275431a216'
+        - '@git.3e96f8ea51c5384045ecdab5467107a58778617c'
         - configurations=MOM6-CICE6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
@@ -35,7 +35,7 @@ spack:
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access3-share:
       require:
-        - '@git.6cfc07bfa474339fdb6c0d1d53896e275431a216'
+        - '@git.3e96f8ea51c5384045ecdab5467107a58778617c'
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,17 +16,17 @@ spack:
     access3:
       require:
         - '@git.33c3e2791df4e048aff49359b61718084dc14cdf'
-        - configurations=MOM6-CICE6
+        - configurations=MOM6
         - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
         - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
-    access-cice:
-      require:
-        - '@git.ccf9fef7003ea44e30a76164d06dbce729b88b9f'
-        - io_type=PIO
-        - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
-        - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
-        - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+    # access-cice:
+    #   require:
+    #     - '@git.ccf9fef7003ea44e30a76164d06dbce729b88b9f'
+    #     - io_type=PIO
+    #     - 'fflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+    #     - 'cflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
+    #     - 'cxxflags="-march=skylake-avx512 -mtune=skylake-avx512 -unroll"'
     access-mom6:
       require:
         - '@2025.07.000'


### PR DESCRIPTION
This builds on @kieranricardo 's recent branch (update-coupled-names). The only difference is that I've needed to 

1. turn of CICE
2. alter the [cmeps mediator file ](https://github.com/ACCESS-NRI/CMEPS/blob/regional-cm3-cmeps1.1.31-x/mediator/esmFldsExchange_access_mod.F90) to remove the hardcoded ice fields in the mediator, so that when ice is turned off for a regional configuration, the mediator doesn't fail when it can't find ice fields

Eventually we want to set things up so that we can share the regional and global cm3 code, but for now I'm trying to keep the rcm3 exe as close as possible to cm3 with a few lines of commented out code sprinkled throughout:
CMEPS, UM and ACCESS-CM3-CONFIGS

See https://github.com/ACCESS-NRI/access-cm3-configs/issues/38

Thanks @anton-seaice for all his help!

---
:rocket: The latest prerelease `access-om3/pr208-11` at 43a3cbd1afdea21b880f4922d7b2b861660db5b1 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/208#issuecomment-4079921590 :rocket:











