### PR TITLE
Release candidate - 2026.03.000

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.002"
+  "access-spack-packages": "2026.03.003"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,7 +8,7 @@ spack:
   # _name and _version are reserved definitions that inform deployments
   definitions:
   - _name: [access-om3]
-  - _version: [2025.08.002]
+  - _version: [2026.03.000]
   specs:
   - access-om3
   packages:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,30 +15,30 @@ spack:
     # Main Dependencies
     access3:
       require:
-      - '@2025.08.000'
+      - '@2026.03.000'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-      - '@CICE6.6.1-0'
+      - '@CICE6.6.3-0'
       - io_type=PIO
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-      - '@2025.07.000'
+      - '@2026.01.001'
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
-      - '@2025.08.000'
+      - '@2026.03.000'
     access3-share:
       require:
-      - '@2025.08.000'
+      - '@2026.03.000'
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -98,7 +98,7 @@ spack:
 
     all:
       prefer:
-      - 'target=x86_64'
+      - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -58,12 +58,15 @@ spack:
     esmf:
       require:
       - '@8.7.0'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback"'
     parallelio:
       require:
       - '@2.6.8'
+      - 'fflags="-g -traceback"'
+      - 'cflags="-g -traceback"'
+      - 'cxxflags="-g -traceback"'
     netcdf-c:
       require:
       - '@4.9.3'

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,7 +44,7 @@ spack:
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-      - '@2025.08.000'
+      - '@2026.02.001'
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -57,7 +57,7 @@ spack:
     # Other Dependencies
     esmf:
       require:
-      - '@8.7.0'
+      - '@8.9.1'
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback"'
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback"'
@@ -73,7 +73,7 @@ spack:
       - build_system=cmake build_type=RelWithDebInfo
     netcdf-fortran:
       require:
-      - '@4.6.1'
+      - '@4.6.2'
     fms:
       require:
       - '@2025.03'


### PR DESCRIPTION
This change:

- updates upstream components (closes #174 and contributes to https://github.com/ACCESS-NRI/access-om3-configs/issues/1028) 
- sets target to x86_64_v4 (closes #200)
- adds debug flags and -grecord-gcc-switches for main components (closes #94 and closes #13 and closes #199)

---
:rocket: The latest prerelease `access-om3/pr209-2` at 12e01ad06096ef0902cca0d7ca700c9457918c71 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/209#issuecomment-4064498896 :rocket:



---
:rocket: The latest prerelease `access-om3/pr209-7` at bb18a6a55b5b654369fb018283e8c976110ed943 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/209#issuecomment-4065197685 :rocket:





