### PR TITLE
Performance optiimisation: Add debug flags, and target cascadelake

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -80,7 +80,7 @@ spack:
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:
-      - '@4.1.7'
+      - '@5.0.8'
     fortranxml:
       require:
       - '@4.1.2'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,50 +17,50 @@ spack:
       require:
       - '@2026.03.000'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
     access-cice:
       require:
       - '@CICE6.6.3-0'
       - io_type=PIO
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
     access-mom6:
       require:
       - '@2026.01.001'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
     access-ww3:
       require:
       - '@2026.03.000'
     access3-share:
       require:
       - '@2026.03.000'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
     access-generic-tracers:
       require:
       - '@2026.02.001'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
     # Other Dependencies
     esmf:
       require:
       - '@8.9.1'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
-      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -unroll -xcascadelake"'
     parallelio:
       require:
       - '@2.6.8'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,50 +17,50 @@ spack:
       require:
       - '@2026.03.000'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
     access-cice:
       require:
       - '@CICE6.6.3-0'
       - io_type=PIO
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
     access-mom6:
       require:
       - '@2026.01.001'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
     access-ww3:
       require:
       - '@2026.03.000'
     access3-share:
       require:
       - '@2026.03.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
     access-generic-tracers:
       require:
       - '@2026.02.001'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
     # Other Dependencies
     esmf:
       require:
       - '@8.9.1'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
+      - 'fflags=" -g3 -grecord-gcc-switches -fno-omit-frame-pointer -O2 -unroll -xcascadelake"'
     parallelio:
       require:
       - '@2.6.8'


### PR DESCRIPTION
Do not merge - I am using this to test performance with various compiler flag combos. Test-bed is with a 20-day run of the 25k IAF config.


### debug flags
The `-g3 -grecord-gcc-switches -fno-omit-frame-pointer` are good to have and do (should?) not have any meaningful impact on performance. We might have to apply the `-fno-omit-frame-pointer` after the optimisation flag (`-O2` here), since `-O1/-O2/etc` implies `-fomit-frame-pointer` (which will presumably cancel out the previous flag). Similarly, `-g` implies `-fno-omit-frame-pointer`

### optimisation flags
Based on[ testing with OM2](https://github.com/ACCESS-NRI/ACCESS-OM2/pull/138), the `-xCORE-AVX2` flags produced a 5-10% performance improvement compared to `-mavx2`/`-march=haswell` etc. Testing whether a similar performance boost occurs by replacing `-march=sapphirerapids -mtune=sapphirerapids` with `-xcascadelake`







---
:rocket: The latest prerelease `access-om3/pr210-3` at b2c0a411a519050845244d73327301f20aacf727 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/210#issuecomment-4107931427 :rocket:


