### PR TITLE
Prerelease with new WOMBATlite default params

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -44,7 +44,7 @@ spack:
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-generic-tracers:
       require:
-      - '@2026.02.001'
+      - '@git.ec5c9b640beb12fe289445fae81202e98d12917b=2026.02.001'  # branch wombatlite-defaultParams
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,7 +29,7 @@ spack:
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-      - '@2026.01.001'
+      - '@git.3c18769be152ab771277b8f18534ab254b3b78c1=2026.01.001'  # branch 48-LF17-nan
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
This prerelease is for testing the [new WOMBATlite default parameters](https://github.com/ACCESS-NRI/GFDL-generic-tracers/issues/114) in ACCESS-OM3

---
:rocket: The latest prerelease `access-om3/pr227-5` at a69984a79771fe2df5eaf2d6302b228ef6e9218e is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/227#issuecomment-4457188726 :rocket:




