### PR TITLE
Prerelease for testing OBC boundary fix

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -29,7 +29,7 @@ spack:
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-      - '@2026.01.001'
+      - '@git.9a5305d219a33201f20ea8105cee978a9c030247=2026.01.001'  # On branch 54-obc-wind-stress
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'

--- a/spack.yaml
+++ b/spack.yaml
@@ -84,6 +84,9 @@ spack:
     fortranxml:
       require:
       - '@4.1.2'
+    python:
+      require:
+      - '@3.11.7'
 
     # Compilers
     c:


### PR DESCRIPTION
This prerelease is for people wanting to test their rOM3 configurations with [fix in MOM6](https://github.com/ACCESS-NRI/MOM6/issues/54) for the [recently discovered boundary issue](https://github.com/ACCESS-NRI/access-om3-configs/issues/1334).

---
:rocket: The latest prerelease `access-om3/pr230-6` at 136a4907d0e1bcbd8ed9d4941c6c32e74bd23406 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/230#issuecomment-4550846165 :rocket:




