### PR TITLE
Prerelease for testing Joey's MOM6 numerical mixing diagnostic

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,8 @@ spack:
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-      - '@2026.05.000'
+      - '@git.9b1dd0431d1eeb77af730251fbf847a80d89817c=2026.05.000'  # On jib/numerical-mixing
+      - +mom6_solo
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:


### PR DESCRIPTION
This prerelease is for testing @jbisits' MOM6 numerical mixing diagnostic

---
:rocket: The latest prerelease `access-om3/pr233-1` at b19ac3775b7f4073d2a10ab38e8b8bbef79bdec0 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/233#issuecomment-4598962573 :rocket:
