### PR TITLE
2026.05.001 release

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -8,7 +8,7 @@ spack:
   # _name and _version are reserved definitions that inform deployments
   definitions:
   - _name: [access-om3]
-  - _version: [2026.05.000]
+  - _version: [2026.05.001]
   specs:
   - access-om3
   packages:
@@ -28,6 +28,7 @@ spack:
     access-mom6:
       require:
       - '@2026.05.000'
+      - +mom6_solo
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:


### PR DESCRIPTION
Apologies, I forgot to add `+mom6_solo` in the 2026.05.000 release

---
:rocket: The latest prerelease `access-om3/pr235-1` at 665a3795e8445be7bfef92918d8aa368c35c022b is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/235#issuecomment-4599288810 :rocket:
