### PR TITLE
Re-build access-om3/pr236-2 due to deletion from Retracting A Release PR

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
 spack: 
   # _name and _version are reserved definitions that inform deployments
-  definitions:
+  definitions: 
   - _name: [access-om3]
   - _version: [2026.05.001]
   specs:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 # Instructions for editing this file are found in
 # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml
-spack:
+spack: 
   # _name and _version are reserved definitions that inform deployments
   definitions:
   - _name: [access-om3]

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-      - '@2026.05.000'
+      - '@git.51a04581700ab5d02e81dc3e85406a9a118061e5'
       - +mom6_solo
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
Related: https://github.com/ACCESS-NRI/ACCESS-OM3/issues/239

DO NOT MERGE

---
:rocket: The latest prerelease `access-om3/pr240-2` at 7b047090e692f295066569e7549e68d4f0074f3d is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/240#issuecomment-4686487105 :rocket:

