### PR TITLE
Prerelease for early access to `FILE_DYE_TRACERS_ACCUMULATE`

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-      - '@2026.05.001'
+      - '@git.40926fbacda30dd99936af3ab85bbcbcda4115c9=2026.05.001'
       - +mom6_solo
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
Angus has [made the accumulation of the `USE_FILE_DYES` tracer optional](https://github.com/ACCESS-NRI/MOM6/pull/67). This has been merged into our fork of MOM6 and will be available in the next ACCESS-OM3 release. In the meantime, this prerelease is for those wanting to use the functionality.

---
:rocket: The latest prerelease `access-om3/pr257-1` at 55b9282b46c32646ce7cea6c57470ee7ddd719aa is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/257#issuecomment-5088211324 :rocket:
