### PR TITLE
Testing deploying with compiler-generated profiling info for various configs and benchmark_ALE

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -17,8 +17,8 @@ spack:
       require:
       - '@2026.03.002'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access-cice:
       require:
       - '@CICE6.6.3-1'
@@ -34,20 +34,22 @@ spack:
     access-ww3:
       require:
       - '@2026.03.000'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access3-share:
       require:
       - '@2026.03.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access-generic-tracers:
       require:
       - '@2026.05.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     # Other Dependencies
     esmf:
       require:
@@ -71,8 +73,8 @@ spack:
     fms:
       require:
       - '@2025.03'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,46 +17,46 @@ spack:
       require:
       - '@2026.03.002'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
     access-cice:
       require:
       - '@CICE6.6.3-1'
       - io_type=PIO
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
     access-mom6:
       require:
       - '@2026.05.001'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
     access-ww3:
       require:
       - '@2026.03.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
     access3-share:
       require:
       - '@2026.03.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
     access-generic-tracers:
       require:
       - '@2026.05.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
     # Other Dependencies
     esmf:
       require:
       - '@8.9.1'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-generate"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
     parallelio:
       require:
       - '@2.6.8'
@@ -73,8 +73,8 @@ spack:
     fms:
       require:
       - '@2025.03'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,8 +29,8 @@ spack:
       require:
       - '@git.4e77c6658a4182e5002a436b2bb538f06263bd33'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_4e77c6658_prof_gen.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_4e77c6658_prof_gen.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
       - '@2026.03.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,46 +17,46 @@ spack:
       require:
       - '@2026.03.002'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access-cice:
       require:
       - '@CICE6.6.3-1'
       - io_type=PIO
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access-mom6:
       require:
       - '@git.4e77c6658a4182e5002a436b2bb538f06263bd33'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access-ww3:
       require:
       - '@2026.03.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access3-share:
       require:
       - '@2026.03.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access-generic-tracers:
       require:
       - '@2026.05.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     # Other Dependencies
     esmf:
       require:
       - '@8.9.1'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-generate"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     parallelio:
       require:
       - '@2.6.8'
@@ -73,8 +73,8 @@ spack:
     fms:
       require:
       - '@2025.03'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -23,14 +23,14 @@ spack:
       require:
       - '@CICE6.6.3-1'
       - io_type=PIO
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access-mom6:
       require:
       - '@2026.05.001'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_4e77c6658_prof_gen.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_4e77c6658_prof_gen.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access-ww3:
       require:
       - '@2026.03.000'
@@ -52,9 +52,9 @@ spack:
     esmf:
       require:
       - '@8.9.1'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-generate"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-generate"'
     parallelio:
       require:
       - '@2.6.8'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,46 +17,46 @@ spack:
       require:
       - '@2026.03.002'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
     access-cice:
       require:
       - '@CICE6.6.3-1'
       - io_type=PIO
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
     access-mom6:
       require:
       - '@git.4e77c6658a4182e5002a436b2bb538f06263bd33'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
     access-ww3:
       require:
       - '@2026.03.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
     access3-share:
       require:
       - '@2026.03.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
     access-generic-tracers:
       require:
       - '@2026.05.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
     # Other Dependencies
     esmf:
       require:
       - '@8.9.1'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -qopt-mem-layout-trans=4"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=4"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=4"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -qopt-mem-layout-trans=3"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=3"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=3"'
     parallelio:
       require:
       - '@2.6.8'
@@ -73,8 +73,8 @@ spack:
     fms:
       require:
       - '@2025.03'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,46 +17,46 @@ spack:
       require:
       - '@2026.03.002'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access-cice:
       require:
       - '@CICE6.6.3-1'
       - io_type=PIO
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access-mom6:
       require:
-      - '@2026.05.001'
+      - '@git.4e77c6658a4182e5002a436b2bb538f06263bd33'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access-ww3:
       require:
       - '@2026.03.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access3-share:
       require:
       - '@2026.03.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access-generic-tracers:
       require:
       - '@2026.05.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
     # Other Dependencies
     esmf:
       require:
       - '@8.9.1'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-generate"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-generate"'
     parallelio:
       require:
       - '@2.6.8'
@@ -73,8 +73,8 @@ spack:
     fms:
       require:
       - '@2025.03'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-3da25e55/access-om3-25k-IAF-Jul28-1year-3da25e55.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-generate"'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,46 +17,46 @@ spack:
       require:
       - '@2026.03.002'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access-cice:
       require:
       - '@CICE6.6.3-1'
       - io_type=PIO
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access-mom6:
       require:
       - '@git.4e77c6658a4182e5002a436b2bb538f06263bd33'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access-ww3:
       require:
       - '@2026.03.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access3-share:
       require:
       - '@2026.03.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access-generic-tracers:
       require:
       - '@2026.05.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     # Other Dependencies
     esmf:
       require:
       - '@8.9.1'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
     parallelio:
       require:
       - '@2.6.8'
@@ -73,8 +73,8 @@ spack:
     fms:
       require:
       - '@2025.03'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use="/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,46 +17,46 @@ spack:
       require:
       - '@2026.03.002'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
     access-cice:
       require:
       - '@CICE6.6.3-1'
       - io_type=PIO
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
     access-mom6:
       require:
       - '@git.4e77c6658a4182e5002a436b2bb538f06263bd33'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
     access-ww3:
       require:
       - '@2026.03.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
     access3-share:
       require:
       - '@2026.03.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
     access-generic-tracers:
       require:
       - '@2026.05.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
     # Other Dependencies
     esmf:
       require:
       - '@8.9.1'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -qopt-mem-layout-trans=2"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=2"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=2"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer"'
     parallelio:
       require:
       - '@2.6.8'
@@ -73,8 +73,8 @@ spack:
     fms:
       require:
       - '@2025.03'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/rom3/superaus-RYF-3month/access-rom3-superaus-RYF-3month-B0_combo_3mo-49cccdbc.pgo"'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,8 +29,8 @@ spack:
       require:
       - '@2026.05.001'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_baseline_prof_gen.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_baseline_prof_gen.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_4e77c6658_prof_gen.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_4e77c6658_prof_gen.pgo"'
     access-ww3:
       require:
       - '@2026.03.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,46 +17,46 @@ spack:
       require:
       - '@2026.03.002'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
     access-cice:
       require:
       - '@CICE6.6.3-1'
       - io_type=PIO
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
     access-mom6:
       require:
       - '@git.4e77c6658a4182e5002a436b2bb538f06263bd33'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
     access-ww3:
       require:
       - '@2026.03.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
     access3-share:
       require:
       - '@2026.03.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
     access-generic-tracers:
       require:
       - '@2026.05.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
     # Other Dependencies
     esmf:
       require:
       - '@8.9.1'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -qopt-mem-layout-trans=4"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=4"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=4"'
     parallelio:
       require:
       - '@2.6.8'
@@ -73,8 +73,8 @@ spack:
     fms:
       require:
       - '@2025.03'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/om3/25k-jra-iaf/1year-15623b40/access-om3-25k-IAF-Jul28-1year-47-perf-rho-remap-diags-15623b40.pgo"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=4"'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -29,8 +29,8 @@ spack:
       require:
       - '@git.4e77c6658a4182e5002a436b2bb538f06263bd33'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_baseline_prof_gen.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_baseline_prof_gen.pgo"'
     access-ww3:
       require:
       - '@2026.03.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -17,46 +17,46 @@ spack:
       require:
       - '@2026.03.002'
       - configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
     access-cice:
       require:
       - '@CICE6.6.3-1'
       - io_type=PIO
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
     access-mom6:
       require:
       - '@git.4e77c6658a4182e5002a436b2bb538f06263bd33'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
     access-ww3:
       require:
       - '@2026.03.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
     access3-share:
       require:
       - '@2026.03.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
     access-generic-tracers:
       require:
       - '@2026.05.000'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
     access-mocsy:
       require:
       - '@2025.07.002'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
     # Other Dependencies
     esmf:
       require:
       - '@8.9.1'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -qopt-mem-layout-trans=3"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=3"'
-      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=3"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -traceback -qopt-mem-layout-trans=2"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=2"'
+      - 'cxxflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fno-omit-frame-pointer -qopt-mem-layout-trans=2"'
     parallelio:
       require:
       - '@2.6.8'
@@ -73,8 +73,8 @@ spack:
     fms:
       require:
       - '@2025.03'
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=3"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -qopt-mem-layout-trans=2"'
       - 'cppflags="-DMAXFIELDMETHODS_=600"'
     openmpi:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,10 +27,10 @@ spack:
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-      - '@2026.05.001'
+      - '@git.4e77c6658a4182e5002a436b2bb538f06263bd33'
       - +mom6_solo
-      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
-      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
+      - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_4e77c6658_prof_gen.pgo"'
+      - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_4e77c6658_prof_gen.pgo"'
     access-ww3:
       require:
       - '@2026.03.000'

--- a/spack.yaml
+++ b/spack.yaml
@@ -27,7 +27,7 @@ spack:
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-      - '@git.4e77c6658a4182e5002a436b2bb538f06263bd33'
+      - '@2026.05.001'
       - +mom6_solo
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_baseline_prof_gen.pgo"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll -fprofile-use=/g/data/tm70/profiling_data/benchmark_ALE/MOM6_baseline_prof_gen.pgo"'


### PR DESCRIPTION
benchmark_ALE test case had a fairly big performance impact from using a 3-stage compilation process - i) compile with `-fprofile-generate` & run benchmark ii) combine generated `profraw` binary files into a single profile file (using `llvm-profdata merge`) and iii) recompile with `-fprofile-use=/path/to/single/profile/file`

Ideally, each config is compiled with it's own profile info, but it might be a reasonable trade-off to compile with a single profiling info that is generated from raw profiling data from all the configs and test cases.

This PR is to come up with some performance numbers to help us make that choice.


### Performance summary table (25k IAF config)
From a single 30-day run of the experiments, so the numbers have some (unknown) error-bars on them. The profiling info in the first 6 build-cd deployments (i.e., `pr258-1` through `pr258-6`, inclusive) are all from benchmark_ALE case. `pr258-11` and `pr258-14` using profiling info from a 1-year run with OM3 25k IAF.

| yrs/Wday | WTime (max ocn/wtime) |   SUs  |  CPUs | yrs/core/Wday | Directory                                
|----------|-----------------------|--------|-------|---------------|------------------------------------------
|      7.5 |         190.9 (81.3%) |  17207 |  2704 |      2.79e-03 | 25km_jra_iaf_Jul28_1yr_pr258-12_profile_generate (MOM6 with `47-perf-rho-remap-diags`, 1-year profile generation run)
|      7.5 |          15.9 (69.6%) |   1429 |  2704 |      2.76e-03 | 25km_jra_iaf_Jul28_30days_pr258-3 ( MOM6 with `47-perf-rho-remap-diags`, no profiling info)
|      7.4 |          15.9 (69.2%) |   1433 |  2704 |      2.75e-03 | 25km_jra_iaf_Jul28_30days_pr258-1 (MOM6 with `47-perf-rho-remap-diags`, and `47-perf-rho-remap-diags` profiling info)
|      7.4 |          15.9 (69.1%) |   1437 |  2704 |      2.74e-03 | 25km_jra_iaf_Jul28_30days_pr258-14-perf-remap-rho-profile-use (MOM6 with `47-perf-rho-remap-diags`, **OM3 25k IAF** profiling info for 1 year)
|      7.3 |          16.2 (68.7%) |   1456 |  2704 |      2.71e-03 | 25km_jra_iaf_Jul28_30days_pr258-4 (MOM6 with `47-perf-rho-remap-diags`, `dev/gfdl` profiling info)
|      7.2 |          16.4 (69.0%) |   1476 |  2704 |      2.67e-03 | 25km_jra_iaf_Jul28_30days_pr258-11-baseline-profile-use (deployed MOM6, **OM3 25k IAF** profiling info for 1 year)
|      7.2 |          16.5 (70.4%) |   1483 |  2704 |      2.66e-03 | 25km_jra_iaf_Jul28_30days_pr258-5 (deployed MOM6, `dev/gfdl` profiling info)
|      7.1 |         201.5 (85.2%) |  18161 |  2704 |      2.64e-03 | 25km_jra_iaf_Jul28_1yr_pr258-10_profile_generate (deployed MOM6, 1-year profile generation run)
|      6.8 |          17.4 (71.4%) |   1570 |  2704 |      2.51e-03 | 25km_jra_iaf_Jul28_30days (**baseline with official deployment**)
|      6.5 |          18.1 (63.4%) |   1634 |  2704 |      2.41e-03 | 25km_jra_iaf_Jul28_30days_pr258-6 (deployed MOM6, `47-perf-rho-remap-diags` profiling info)


### Performance summary table (25k RYF config)
From a set of 3 runs, with `repeat=True` for a 30-day experiment. The profiling info in the first 6 build-cd deployments (i.e., `pr258-1` through `pr258-6`, inclusive) are all from `benchmark_ALE` case. `pr258-11` and `pr258-14` using profiling info from a 1-year run with OM3 25k IAF.

| yrs/Wday | WTime (max ocn/wtime) |   SUs  |  CPUs | yrs/core/Wday | Directory                                
|-----------|-------------------------|-------|-------|---------------|------------------------------------------
|      7.9 |          15.0 (70.1%) |   1348 |  2704 |      2.93e-03 | 25km_jra_ryf_Aug4_30days_pr258-14 
|      7.9 |          15.0 (70.0%) |   1353 |  2704 |      2.91e-03 | 25km_jra_ryf_Aug4_30days_pr258-1 
|      7.8 |          15.2 (69.5%) |   1372 |  2704 |      2.87e-03 | 25km_jra_ryf_Aug4_30days_pr258-4 
|      7.8 |          15.2 (69.5%) |   1374 |  2704 |      2.87e-03 | 25km_jra_ryf_Aug4_30days_pr258-3 
|      7.7 |          15.3 (70.9%) |   1379 |  2704 |      2.86e-03 | 25km_jra_ryf_Aug4_30days_pr258-11 
|      7.5 |          15.7 (70.6%) |   1418 |  2704 |      2.78e-03 | 25km_jra_ryf_Aug4_30days_pr258-5 
|      7.1 |          16.6 (72.3%) |   1494 |  2704 |      2.64e-03 | 25km_jra_ryf_Aug4_30days 


### Performance summary table (100k IAF config)
From a set of 3 runs, with `repeat=True` for a 1-year experiment. The profiling info in the first 6 build-cd deployments (i.e., `pr258-1` through `pr258-6`, inclusive) are all from `benchmark_ALE` case. `pr258-11` and `pr258-14` using profiling info from a 1-year run with OM3 25k IAF. Since the base config runs on the `normal` (i.e., `cascadelake` queue) - this uncovered a hidden variable of the hardware as well -- both `pr258-11` and `pr258-14`  **crashed with illegal instruction error**. 

| yrs/Wday | WTime (max ocn/wtime) |   SUs  |  CPUs | yrs/core/Wday | Directory                                
|----------|-----------------------|--------|-------|---------------|------------------------------------------
|     27.3 |          52.7 (91.1%) |    422 |   240 |      1.14e-01 | 100km_jra_iaf_Aug5_1year_cascadelake_pr258-3 
|     27.0 |          53.4 (90.9%) |    427 |   240 |      1.12e-01 | 100km_jra_iaf_Aug5_1year_cascadelake_pr258-1 
|     26.8 |          53.8 (91.5%) |    431 |   240 |      1.11e-01 | 100km_jra_iaf_Aug5_1year_cascadelake_pr258-5 
|     25.5 |          56.5 (92.6%) |    452 |   240 |      1.06e-01 | 100km_jra_iaf_Aug5_1year_cascadelake 

---
:rocket: The latest prerelease `access-om3/pr258-18` at b1cced712a881e3f34453d1e9f8739c02a0c7b0e is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/258#issuecomment-5137203353 :rocket:





---
:rocket: The latest prerelease `access-om3/pr258-19` at ac16be0521a71dd3228ea63fe97fd1d022c0c0d2 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/258#issuecomment-5234753805 :rocket:
