### PR TITLE
2026.05.003 new build

### DIFF
--- a/config/auto-configs-pr.json
+++ b/config/auto-configs-pr.json
@@ -19,6 +19,11 @@
           "checks": {
             "repro": true
           }
+        },
+        "dev-MCW_100km_jra_iaf": {
+          "checks": {
+            "repro": true
+          }
         }
       }
     }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.06.000"
+  "access-spack-packages": "2026.08.005"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -21,19 +21,19 @@ spack:
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-cice:
       require:
-      - '@CICE6.6.3-1'
+      - '@CICE6.6.3-2'
       - io_type=PIO
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-      - '@2026.05.001'
+      - '@2026.05.002'
       - +mom6_solo
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-ww3:
       require:
-      - '@2026.03.000'
+      - '@2026.03.001'
     access3-share:
       require:
       - '@2026.03.002'

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,7 +8,7 @@ spack:
   # _name and _version are reserved definitions that inform deployments
   definitions:
   - _name: [access-om3]
-  - _version: [2026.05.002]
+  - _version: [2026.05.003]
   specs:
   - access-om3
   packages:


### PR DESCRIPTION
Fixes for the following:

MOM6:
- Add minimum thickness clamp in mixedlayer_restrat_Bodner (by @dougiesquire in https://github.com/ACCESS-NRI/MOM6/pull/61)
- Add FILE_DYE_TRACER_ACCUMULATE param to the file-based dye tracer (by @angus-g in https://github.com/ACCESS-NRI/MOM6/pull/67)
- Save correct thickness value for diagnostic vert_remap_h (by @jbisits in https://github.com/ACCESS-NRI/MOM6/pull/66)
- Add a numerical mixing diagnostic (by @jbisits in https://github.com/ACCESS-NRI/MOM6/pull/57)

CICE6:
- Fix ANGLE and tripole closure in MOM supergrid by @anton-seaice in https://github.com/ACCESS-NRI/CICE/pull/50

WW3:
- Remove W3_IS2 compile guard from IC5 floe diameter update by @ezhilsabareesh8 in https://github.com/ACCESS-NRI/WW3/pull/15
- Avoid ST6 IRANGE heap allocations in source loops by @ezhilsabareesh8 in https://github.com/ACCESS-NRI/WW3/pull/16

---
:rocket: The latest prerelease `access-om3/pr260-5` at 40e8f5d91b16b76094b50a15e36f2562d47e70c4 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/260#issuecomment-5234741392 :rocket:




