### PR TITLE
Test build CD v9

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -8,7 +8,7 @@ spack:
   # _name and _version are reserved definitions that inform deployments
   definitions:
   - _name: [access-om3]
-  - _version: [2026.05.003]
+  - _version: [2026.05.003-0]
   # _spack-version and _custom-scopes inform the branch of spack to use, and custom scopes if applicable, respectively
   - _spack-version: ["1.1"]
   # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules


### PR DESCRIPTION
Try to build the latest deployument after built CD v9 update

---
:rocket: The latest prerelease `access-om3/pr262-1` at 7e16023378c061a9e10f130b2fcc2958a0c59cd0 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/262#issuecomment-5260338675 :rocket:


---
:rocket: The latest prerelease `access-om3/pr262-2` at 7e16023378c061a9e10f130b2fcc2958a0c59cd0 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/262#issuecomment-5260782399 :rocket:
