### PR TITLE
Build with the patched MOM6

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -32,7 +32,7 @@ spack:
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
     access-mom6:
       require:
-      - '@2026.05.002'
+      - '@git.358db9c551e052eff0600b9aa026f51bbbaba1a9'
       - +mom6_solo
       - 'fflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'
       - 'cflags="-march=sapphirerapids -mtune=sapphirerapids -unroll"'


### PR DESCRIPTION
Testing the Claude generated patch for MOM6 nonblocking updates

---
:rocket: The latest prerelease `access-om3/pr263-1` at 3ad12bed9ddf96416d52b2889d35776f54572951 is here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/263#issuecomment-5452558291 :rocket:

